### PR TITLE
Add intraday regression-based microstructure features

### DIFF
--- a/cube2mat/features/absret_sqrtvol_slope.py
+++ b/cube2mat/features/absret_sqrtvol_slope.py
@@ -1,0 +1,79 @@
+# features/absret_sqrtvol_slope.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class AbsRetSqrtVolSlopeFeature(BaseFeature):
+    """
+    09:30–15:59 内，对每个 symbol 回归：
+      |ret_t| ~ sqrt(volume_t)
+    其中 ret = close.pct_change()；过滤无效/非正 volume。输出斜率；若样本<2 或 var(sqrt(volume))=0 则 NaN。
+    """
+    name = "absret_sqrtvol_slope"
+    description = "OLS slope of |ret| on sqrt(volume) within 09:30–15:59; NaN if insufficient."
+    required_full_columns = ("symbol", "time", "close", "volume")
+    required_pv_columns = ("symbol",)
+
+    @staticmethod
+    def _ols_slope(x: pd.Series, y: pd.Series) -> float:
+        n = len(x)
+        if n < 2:
+            return np.nan
+        xm = x.mean(); ym = y.mean()
+        xd = x - xm; yd = y - ym
+        den = (xd * xd).sum()
+        if den <= 0:
+            return np.nan
+        num = (xd * yd).sum()
+        return float(num / den)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, columns=list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, columns=list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df[df["symbol"].isin(set(sample["symbol"].unique()))]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.copy()
+        for c in ("close", "volume"):
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+        df = df.dropna(subset=["close", "volume"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.sort_index()
+        df["ret"] = df.groupby("symbol", sort=False)["close"].pct_change()
+        df["ret"] = df["ret"].replace([np.inf, -np.inf], np.nan)
+        df = df.dropna(subset=["ret"])
+
+        # 对齐 volume 与 ret（首个 ret 缺失已剔除）
+        df = df[df["volume"] > 0]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["x"] = np.sqrt(df["volume"])
+        df["y"] = df["ret"].abs()
+
+        value = df.groupby("symbol").apply(lambda g: self._ols_slope(g["x"], g["y"]))
+        out["value"] = out["symbol"].map(value)
+        return out
+
+feature = AbsRetSqrtVolSlopeFeature()

--- a/cube2mat/features/amihud_illiquidity.py
+++ b/cube2mat/features/amihud_illiquidity.py
@@ -1,0 +1,67 @@
+# features/amihud_illiquidity.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class AmihudIlliquidityFeature(BaseFeature):
+    """
+    09:30–15:59 内，Amihud 非流动性：
+      ILLIQ = mean_t( |ret_t| / (vwap_t * volume_t) )
+    其中 ret = close.pct_change()；过滤无效/零或负的 vwap/volume。
+    若有效样本<1，则 NaN。
+    """
+    name = "amihud_illiquidity"
+    description = "Amihud illiquidity: mean(|ret| / (vwap*volume)) within 09:30–15:59; NaN if insufficient data."
+    required_full_columns = ("symbol", "time", "close", "vwap", "volume")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, columns=list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, columns=list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df[df["symbol"].isin(set(sample["symbol"].unique()))]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.copy()
+        for c in ("close", "vwap", "volume"):
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+
+        df = df.dropna(subset=["close", "vwap", "volume"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.sort_index()
+        df["ret"] = df.groupby("symbol", sort=False)["close"].pct_change()
+        df["ret"] = df["ret"].replace([np.inf, -np.inf], np.nan)
+        df = df.dropna(subset=["ret"])
+
+        # 过滤非正的 vwap 或 volume
+        df = df[(df["vwap"] > 0) & (df["volume"] > 0)]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["illiq"] = (df["ret"].abs()) / (df["vwap"] * df["volume"])
+        value = df.groupby("symbol")["illiq"].mean()
+
+        out["value"] = out["symbol"].map(value)
+        return out
+
+feature = AmihudIlliquidityFeature()

--- a/cube2mat/features/ar1_ret_coef.py
+++ b/cube2mat/features/ar1_ret_coef.py
@@ -1,0 +1,84 @@
+# features/ar1_ret_coef.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class AR1RetCoefFeature(BaseFeature):
+    """
+    09:30–15:59 内，计算 ret_t = α + φ * ret_{t-1} + ε 的 OLS φ（AR(1) 系数）。
+    其中 ret = close.pct_change()，清理 inf/NaN。若有效样本对 < 3（即 ret 数≥4）或 var(ret_{t-1})=0，则 NaN。
+    """
+    name = "ar1_ret_coef"
+    description = "AR(1) coefficient φ for intraday simple returns ret=close.pct_change(), within 09:30–15:59."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    @staticmethod
+    def _ols_beta(x: pd.Series, y: pd.Series) -> float:
+        n = len(x)
+        if n < 3:
+            return np.nan
+        xm = x.mean(); ym = y.mean()
+        xd = x - xm; yd = y - ym
+        den = (xd * xd).sum()
+        if den <= 0:
+            return np.nan
+        num = (xd * yd).sum()
+        return float(num / den)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, columns=list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, columns=list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df[df["symbol"].isin(set(sample["symbol"].unique()))]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.copy()
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.sort_index()
+        # 计算 ret
+        df["ret"] = df.groupby("symbol", sort=False)["close"].pct_change()
+        df["ret"] = df["ret"].replace([np.inf, -np.inf], np.nan)
+        df = df.dropna(subset=["ret"])
+
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        # 构造滞后对
+        df["ret_lag1"] = df.groupby("symbol", sort=False)["ret"].shift(1)
+        df = df.dropna(subset=["ret", "ret_lag1"])
+
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        value = df.groupby("symbol").apply(
+            lambda g: self._ols_beta(g["ret_lag1"], g["ret"])
+        )
+
+        out["value"] = out["symbol"].map(value)
+        return out
+
+feature = AR1RetCoefFeature()

--- a/cube2mat/features/close_on_vwap_beta.py
+++ b/cube2mat/features/close_on_vwap_beta.py
@@ -1,0 +1,66 @@
+# features/close_on_vwap_beta.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class CloseOnVwapBetaFeature(BaseFeature):
+    """
+    09:30–15:59 内，回归 close ~ vwap，输出斜率（beta）。
+    用于刻画 close 对“交易加权锚(vwap)”的弹性；若样本<2 或 var(vwap)=0，则 NaN。
+    """
+    name = "close_on_vwap_beta"
+    description = "OLS slope (beta) of close on vwap within 09:30–15:59; NaN if insufficient."
+    required_full_columns = ("symbol", "time", "close", "vwap")
+    required_pv_columns = ("symbol",)
+
+    @staticmethod
+    def _beta(x: pd.Series, y: pd.Series) -> float:
+        n = len(x)
+        if n < 2:
+            return np.nan
+        xm = x.mean(); ym = y.mean()
+        xd = x - xm; yd = y - ym
+        den = (xd * xd).sum()
+        if den <= 0:
+            return np.nan
+        num = (xd * yd).sum()
+        return float(num / den)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, columns=list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, columns=list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df[df["symbol"].isin(set(sample["symbol"].unique()))]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.copy()
+        for c in ("close", "vwap"):
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+        df = df.dropna(subset=["close", "vwap"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.sort_index()
+        value = df.groupby("symbol").apply(lambda g: self._beta(g["vwap"], g["close"]))
+
+        out["value"] = out["symbol"].map(value)
+        return out
+
+feature = CloseOnVwapBetaFeature()

--- a/cube2mat/features/diff_close_vwap_trend_slope.py
+++ b/cube2mat/features/diff_close_vwap_trend_slope.py
@@ -1,0 +1,66 @@
+# features/diff_close_vwap_trend_slope.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class DiffCloseVwapTrendSlopeFeature(BaseFeature):
+    """
+    09:30–15:59 内，回归 (close - vwap) ~ time(分钟)，输出斜率。
+    捕捉 close 对 VWAP 的“溢价/贴水”日内漂移。若样本<2 或 var(time)=0，则 NaN。
+    """
+    name = "diff_close_vwap_trend_slope"
+    description = "OLS slope of (close - vwap) on minutes-since-09:30 within 09:30–15:59."
+    required_full_columns = ("symbol", "time", "close", "vwap")
+    required_pv_columns = ("symbol",)
+
+    @staticmethod
+    def _ols_slope(x: pd.Series, y: pd.Series) -> float:
+        n = len(x)
+        if n < 2:
+            return np.nan
+        xm = x.mean(); ym = y.mean()
+        xd = x - xm; yd = y - ym
+        den = (xd * xd).sum()
+        if den <= 0:
+            return np.nan
+        num = (xd * yd).sum()
+        return float(num / den)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df_full = self.load_full(ctx, date, columns=list(self.required_full_columns))
+        sample  = self.load_pv(ctx, date, columns=list(self.required_pv_columns))
+        if df_full is None or sample is None:
+            return None
+
+        out = sample[["symbol"]].copy()
+
+        df = self.ensure_et_index(df_full, "time", ctx.tz).between_time("09:30", "15:59")
+        if df is None or df.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df[df["symbol"].isin(set(sample["symbol"].unique()))]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.copy()
+        for c in ("close", "vwap"):
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+        df = df.dropna(subset=["close", "vwap"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.sort_index()
+        tdelta = (df.index - df.index.normalize()) - pd.Timedelta("09:30:00")
+        df["t_min"] = tdelta.total_seconds() / 60.0
+        df["diff"]  = df["close"] - df["vwap"]
+
+        value = df.groupby("symbol").apply(lambda g: self._ols_slope(g["t_min"], g["diff"]))
+        out["value"] = out["symbol"].map(value)
+        return out
+
+feature = DiffCloseVwapTrendSlopeFeature()

--- a/cube2mat/features/impact_slope_price_cumvol.py
+++ b/cube2mat/features/impact_slope_price_cumvol.py
@@ -1,0 +1,85 @@
+# features/impact_slope_price_cumvol.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class ImpactSlopePriceCumVolFeature(BaseFeature):
+    """
+    09:30–15:59 内，回归 y ~ x：
+      y = close - first_open   （以首笔 open 为锚的价格变动）
+      x = 累积成交量 cumsum(volume)
+    输出斜率（单位：价格/股）。若样本<2 或 var(x)=0，则 NaN。
+    若首笔 open 缺失，退化为以首笔 close 为锚。
+    """
+    name = "impact_slope_price_cumvol"
+    description = "OLS slope of (close - first_open) on cumulative volume within 09:30–15:59; NaN if insufficient."
+    required_full_columns = ("symbol", "time", "open", "close", "volume")
+    required_pv_columns = ("symbol",)
+
+    @staticmethod
+    def _ols_slope_xy(x: pd.Series, y: pd.Series) -> float:
+        n = len(x)
+        if n < 2:
+            return np.nan
+        xm = x.mean(); ym = y.mean()
+        xd = x - xm; yd = y - ym
+        den = (xd * xd).sum()
+        if den <= 0:
+            return np.nan
+        num = (xd * yd).sum()
+        return float(num / den)
+
+    @staticmethod
+    def _first_valid(s: pd.Series):
+        s = s.dropna()
+        return None if s.empty else float(s.iloc[0])
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, columns=list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, columns=list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df[df["symbol"].isin(set(sample["symbol"].unique()))]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.copy()
+        for c in ("open", "close", "volume"):
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+        df = df.dropna(subset=["close", "volume"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.sort_index()
+
+        def per_symbol(g: pd.DataFrame) -> float:
+            # 锚定价：优先首个有效 open，否则首个 close
+            first_open = g["open"].dropna()
+            anchor = first_open.iloc[0] if not first_open.empty else g["close"].iloc[0]
+            x = g["volume"].cumsum()
+            y = g["close"] - anchor
+            # 清理
+            mask = x.notna() & y.notna()
+            x = x[mask]; y = y[mask]
+            return ImpactSlopePriceCumVolFeature._ols_slope_xy(x, y)
+
+        value = df.groupby("symbol").apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+feature = ImpactSlopePriceCumVolFeature()

--- a/cube2mat/features/roll_spread.py
+++ b/cube2mat/features/roll_spread.py
@@ -1,0 +1,73 @@
+# features/roll_spread.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class RollSpreadFeature(BaseFeature):
+    """
+    09:30–15:59 内，Roll 有效价差估计：
+      Δp_t = close_t - close_{t-1}
+      gamma = Cov(Δp_t, Δp_{t-1})（样本协方差）
+      若 gamma < 0，spread = 2 * sqrt(-gamma)，否则 NaN。
+    使用 bar 级价格近似成交价。样本<3 或无效时 NaN。
+    """
+    name = "roll_spread"
+    description = "Roll effective spread estimator from lag-1 autocovariance of price changes within 09:30–15:59."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    @staticmethod
+    def _roll_spread_from_series(p: pd.Series) -> float:
+        # p 按时间升序
+        dp = p.diff().dropna()
+        if len(dp) < 2:
+            return np.nan
+        x = dp.iloc[1:].astype(float)
+        y = dp.iloc[:-1].astype(float)
+        # 样本协方差
+        n = len(x)
+        if n < 2:
+            return np.nan
+        xm = x.mean(); ym = y.mean()
+        cov = ((x - xm) * (y - ym)).sum() / (n - 1)
+        if np.isfinite(cov) and cov < 0:
+            val = 2.0 * np.sqrt(-cov)
+            return float(val)
+        return np.nan
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, columns=list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, columns=list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df[df["symbol"].isin(set(sample["symbol"].unique()))]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.copy()
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.sort_index()
+        value = df.groupby("symbol")["close"].apply(self._roll_spread_from_series)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+feature = RollSpreadFeature()

--- a/cube2mat/features/trend_r2_close_time.py
+++ b/cube2mat/features/trend_r2_close_time.py
@@ -1,0 +1,71 @@
+# features/trend_r2_close_time.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class TrendR2CloseTimeFeature(BaseFeature):
+    """
+    09:30–15:59 内，OLS: close ~ time(分钟) 的拟合优度 R^2。
+    若 var(close)=0 或样本<2，则 NaN。
+    """
+    name = "trend_r2_close_time"
+    description = "R^2 of OLS close~time (minutes since 09:30) within 09:30–15:59; NaN if <2 points or var(close)=0."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    @staticmethod
+    def _ols_r2(x: pd.Series, y: pd.Series) -> float:
+        n = len(x)
+        if n < 2:
+            return np.nan
+        xm = x.mean(); ym = y.mean()
+        xd = x - xm; yd = y - ym
+        den = (xd * xd).sum()
+        sst = (yd * yd).sum()
+        if den <= 0 or sst <= 0:
+            return np.nan
+        beta1 = (xd * yd).sum() / den
+        ssr = (beta1 * beta1) * den
+        r2 = ssr / sst
+        return float(r2)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df_full = self.load_full(ctx, date, columns=list(self.required_full_columns))
+        sample  = self.load_pv(ctx, date, columns=list(self.required_pv_columns))
+        if df_full is None or sample is None:
+            return None
+
+        out = sample[["symbol"]].copy()
+        if df_full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(df_full, time_col="time", tz=ctx.tz)
+        df = df.between_time("09:30", "15:59")
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df[df["symbol"].isin(set(sample["symbol"].unique()))]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.copy()
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.sort_index()
+        tdelta = (df.index - df.index.normalize()) - pd.Timedelta("09:30:00")
+        df["t_min"] = tdelta.total_seconds() / 60.0
+
+        value = df.groupby("symbol").apply(lambda g: self._ols_r2(g["t_min"], g["close"]))
+        out["value"] = out["symbol"].map(value)
+        return out
+
+feature = TrendR2CloseTimeFeature()

--- a/cube2mat/features/trend_resid_std.py
+++ b/cube2mat/features/trend_resid_std.py
@@ -1,0 +1,77 @@
+# features/trend_resid_std.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class TrendResidStdFeature(BaseFeature):
+    """
+    09:30–15:59 内，对 close ~ time(分钟) 做回归，返回残差标准差的无偏估计：
+        sigma = sqrt(SSE / (n - 2))。n<3 或 var(time)=0 则 NaN。
+    反映去趋势后的日内“噪声强度”。
+    """
+    name = "trend_resid_std"
+    description = "Unbiased residual std from OLS close~time within 09:30–15:59; sqrt(SSE/(n-2))."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    @staticmethod
+    def _resid_sigma(x: pd.Series, y: pd.Series) -> float:
+        n = len(x)
+        if n < 3:
+            return np.nan
+        xm = x.mean(); ym = y.mean()
+        xd = x - xm; yd = y - ym
+        den = (xd * xd).sum()
+        if den <= 0:
+            return np.nan
+        beta1 = (xd * yd).sum() / den
+        beta0 = ym - beta1 * xm
+        resid = y - (beta0 + beta1 * x)
+        sse = (resid * resid).sum()
+        dof = n - 2
+        if dof <= 0:
+            return np.nan
+        sigma2 = sse / dof
+        if sigma2 < 0:
+            return np.nan
+        return float(np.sqrt(sigma2))
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, columns=list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, columns=list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df[df["symbol"].isin(set(sample["symbol"].unique()))]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.copy()
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.sort_index()
+        tdelta = (df.index - df.index.normalize()) - pd.Timedelta("09:30:00")
+        df["t_min"] = tdelta.total_seconds() / 60.0
+
+        value = df.groupby("symbol").apply(lambda g: self._resid_sigma(g["t_min"], g["close"]))
+        out["value"] = out["symbol"].map(value)
+        return out
+
+feature = TrendResidStdFeature()

--- a/cube2mat/features/trend_slope_close_time.py
+++ b/cube2mat/features/trend_slope_close_time.py
@@ -1,0 +1,74 @@
+# features/trend_slope_close_time.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class TrendSlopeCloseTimeFeature(BaseFeature):
+    """
+    09:30–15:59 内，对每个 symbol 做 OLS: close ~ time(分钟)。
+    输出斜率（单位：价格/分钟）。n<2 或 var(time)=0 时 NaN。
+    """
+    name = "trend_slope_close_time"
+    description = "OLS slope of close on minutes-since-09:30 within 09:30–15:59; NaN if <2 points or var(time)=0."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    @staticmethod
+    def _ols_slope(x: pd.Series, y: pd.Series) -> float:
+        n = len(x)
+        if n < 2:
+            return np.nan
+        xm = x.mean(); ym = y.mean()
+        xd = x - xm; yd = y - ym
+        den = (xd * xd).sum()
+        if not np.isfinite(den) or den <= 0:
+            return np.nan
+        num = (xd * yd).sum()
+        return float(num / den)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df_full = self.load_full(ctx, date, columns=list(self.required_full_columns))
+        sample  = self.load_pv(ctx, date, columns=list(self.required_pv_columns))
+        if df_full is None or sample is None:
+            return None
+
+        out = sample[["symbol"]].copy()
+        if df_full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(df_full, time_col="time", tz=ctx.tz)
+        df = df.between_time("09:30", "15:59")
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        syms = set(sample["symbol"].unique())
+        df = df[df["symbol"].isin(syms)]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.copy()
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.sort_index()
+        # minutes since 09:30
+        tdelta = (df.index - df.index.normalize()) - pd.Timedelta("09:30:00")
+        df["t_min"] = tdelta.total_seconds() / 60.0
+
+        value = (
+            df.groupby("symbol")
+              .apply(lambda g: self._ols_slope(g["t_min"], g["close"]))
+        )
+
+        out["value"] = out["symbol"].map(value)
+        return out
+
+feature = TrendSlopeCloseTimeFeature()

--- a/cube2mat/features/trend_slope_tstat.py
+++ b/cube2mat/features/trend_slope_tstat.py
@@ -1,0 +1,81 @@
+# features/trend_slope_tstat.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class TrendSlopeTstatFeature(BaseFeature):
+    """
+    09:30–15:59 内，OLS: close ~ time(分钟) 的斜率 t 统计量：
+      t = beta1 / SE(beta1), 其中 SE(beta1) = sqrt( sigma^2 / Sxx ),
+      sigma^2 = SSE/(n-2), Sxx = sum((t - mean(t))^2)。
+    若 n<3 或 Sxx<=0 则 NaN。
+    """
+    name = "trend_slope_tstat"
+    description = "t-stat of OLS slope for close~time (minutes since 09:30) within 09:30–15:59."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    @staticmethod
+    def _tstat(x: pd.Series, y: pd.Series) -> float:
+        n = len(x)
+        if n < 3:
+            return np.nan
+        xm = x.mean(); ym = y.mean()
+        xd = x - xm; yd = y - ym
+        sxx = (xd * xd).sum()
+        if sxx <= 0:
+            return np.nan
+        beta1 = (xd * yd).sum() / sxx
+        beta0 = ym - beta1 * xm
+        resid = y - (beta0 + beta1 * x)
+        sse = (resid * resid).sum()
+        dof = n - 2
+        if dof <= 0:
+            return np.nan
+        sigma2 = sse / dof
+        if sigma2 <= 0:
+            return np.nan
+        se_beta1 = np.sqrt(sigma2 / sxx)
+        if se_beta1 == 0:
+            return np.nan
+        return float(beta1 / se_beta1)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, columns=list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, columns=list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df[df["symbol"].isin(set(sample["symbol"].unique()))]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.copy()
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.sort_index()
+        tdelta = (df.index - df.index.normalize()) - pd.Timedelta("09:30:00")
+        df["t_min"] = tdelta.total_seconds() / 60.0
+
+        value = df.groupby("symbol").apply(lambda g: self._tstat(g["t_min"], g["close"]))
+        out["value"] = out["symbol"].map(value)
+        return out
+
+feature = TrendSlopeTstatFeature()

--- a/cube2mat/features/trend_slope_volume_weighted.py
+++ b/cube2mat/features/trend_slope_volume_weighted.py
@@ -1,0 +1,77 @@
+# features/trend_slope_volume_weighted.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class TrendSlopeVolumeWeightedFeature(BaseFeature):
+    """
+    09:30–15:59 内，对每个 symbol 做体量加权回归（WLS）：
+        close ~ time(分钟)，权重 = volume。
+    输出加权斜率；若有效样本<2、权重和<=0 或加权 var(time)=0，则 NaN。
+    """
+    name = "trend_slope_volume_weighted"
+    description = "Volume-weighted OLS slope of close~time (minutes since 09:30) within 09:30–15:59."
+    required_full_columns = ("symbol", "time", "close", "volume")
+    required_pv_columns = ("symbol",)
+
+    @staticmethod
+    def _wls_slope(x: pd.Series, y: pd.Series, w: pd.Series) -> float:
+        # 清理非正权重
+        w = w.clip(lower=0)
+        if (w > 0).sum() < 2:
+            return np.nan
+        W = w.sum()
+        if not np.isfinite(W) or W <= 0:
+            return np.nan
+        xw = (w * x).sum() / W
+        yw = (w * y).sum() / W
+        xd = x - xw
+        yd = y - yw
+        den = (w * (xd * xd)).sum()
+        if not np.isfinite(den) or den <= 0:
+            return np.nan
+        num = (w * (xd * yd)).sum()
+        return float(num / den)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df_full = self.load_full(ctx, date, columns=list(self.required_full_columns))
+        sample  = self.load_pv(ctx, date, columns=list(self.required_pv_columns))
+        if df_full is None or sample is None:
+            return None
+
+        out = sample[["symbol"]].copy()
+        if df_full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(df_full, time_col="time", tz=ctx.tz).between_time("09:30", "15:59")
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df[df["symbol"].isin(set(sample["symbol"].unique()))]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.copy()
+        df["close"]  = pd.to_numeric(df["close"],  errors="coerce")
+        df["volume"] = pd.to_numeric(df["volume"], errors="coerce")
+        df = df.dropna(subset=["close", "volume"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.sort_index()
+        tdelta = (df.index - df.index.normalize()) - pd.Timedelta("09:30:00")
+        df["t_min"] = tdelta.total_seconds() / 60.0
+
+        value = df.groupby("symbol").apply(
+            lambda g: self._wls_slope(g["t_min"], g["close"], g["volume"])
+        )
+        out["value"] = out["symbol"].map(value)
+        return out
+
+feature = TrendSlopeVolumeWeightedFeature()


### PR DESCRIPTION
## Summary
- add close~time trend slope, R^2 and t-statistics features
- add regression-based microstructure metrics like AR(1) return coef, Roll spread, Amihud illiquidity and more

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a02a9feedc832abd9990c8b812066d