### PR TITLE
Add close-volume and close-n relation features

### DIFF
--- a/cube2mat/features/close_on_logn_beta.py
+++ b/cube2mat/features/close_on_logn_beta.py
@@ -1,0 +1,66 @@
+# features/close_on_logn_beta.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class CloseOnLogNBetaFeature(BaseFeature):
+    """
+    09:30–15:59 内，OLS: close ~ log(n)。仅使用 n>0 的样本。
+    若有效样本<2 或 var(log(n))=0，则 NaN。
+    """
+
+    name = "close_on_logn_beta"
+    description = "OLS slope of close on log(n) within 09:30–15:59; NaN if insufficient."
+    required_full_columns = ("symbol", "time", "close", "n")
+    required_pv_columns = ("symbol",)
+
+    @staticmethod
+    def _ols_slope(x: pd.Series, y: pd.Series) -> float:
+        n = len(x)
+        if n < 2:
+            return np.nan
+        xd = x - x.mean()
+        yd = y - y.mean()
+        sxx = (xd * xd).sum()
+        if sxx <= 0:
+            return np.nan
+        return float(((xd * yd).sum()) / sxx)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, columns=list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, columns=list(self.required_pv_columns))
+        out = sample[["symbol"]].copy() if sample is not None else None
+        if full is None or sample is None:
+            return None
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(set(sample["symbol"].unique()))]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.copy()
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df["n"] = pd.to_numeric(df["n"], errors="coerce")
+        df = df.dropna(subset=["close", "n"])
+        df = df[df["n"] > 0]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["log_n"] = np.log(df["n"])
+        df = df.sort_index()
+        value = df.groupby("symbol").apply(
+            lambda g: self._ols_slope(g["log_n"], g["close"])
+        )
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = CloseOnLogNBetaFeature()

--- a/cube2mat/features/close_on_logvolume_beta.py
+++ b/cube2mat/features/close_on_logvolume_beta.py
@@ -1,0 +1,66 @@
+# features/close_on_logvolume_beta.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class CloseOnLogVolumeBetaFeature(BaseFeature):
+    """
+    09:30–15:59 内，OLS: close ~ log(volume)。仅使用 volume>0 的样本。
+    若有效样本<2 或 var(log(volume))=0，则 NaN。
+    """
+
+    name = "close_on_logvolume_beta"
+    description = "OLS slope of close on log(volume) within 09:30–15:59; NaN if insufficient."
+    required_full_columns = ("symbol", "time", "close", "volume")
+    required_pv_columns = ("symbol",)
+
+    @staticmethod
+    def _ols_slope(x: pd.Series, y: pd.Series) -> float:
+        n = len(x)
+        if n < 2:
+            return np.nan
+        xd = x - x.mean()
+        yd = y - y.mean()
+        sxx = (xd * xd).sum()
+        if sxx <= 0:
+            return np.nan
+        return float(((xd * yd).sum()) / sxx)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, columns=list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, columns=list(self.required_pv_columns))
+        out = sample[["symbol"]].copy() if sample is not None else None
+        if full is None or sample is None:
+            return None
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(set(sample["symbol"].unique()))]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.copy()
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df["volume"] = pd.to_numeric(df["volume"], errors="coerce")
+        df = df.dropna(subset=["close", "volume"])
+        df = df[df["volume"] > 0]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["log_vol"] = np.log(df["volume"])
+        df = df.sort_index()
+        value = df.groupby("symbol").apply(
+            lambda g: self._ols_slope(g["log_vol"], g["close"])
+        )
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = CloseOnLogVolumeBetaFeature()

--- a/cube2mat/features/close_on_n_beta.py
+++ b/cube2mat/features/close_on_n_beta.py
@@ -1,0 +1,63 @@
+# features/close_on_n_beta.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class CloseOnNBetaFeature(BaseFeature):
+    """
+    09:30–15:59 内，OLS: close ~ n（成交笔数）。样本<2 或 var(n)=0 则 NaN。
+    """
+
+    name = "close_on_n_beta"
+    description = "OLS slope of close on number of trades n within 09:30–15:59."
+    required_full_columns = ("symbol", "time", "close", "n")
+    required_pv_columns = ("symbol",)
+
+    @staticmethod
+    def _ols_slope(x: pd.Series, y: pd.Series) -> float:
+        n = len(x)
+        if n < 2:
+            return np.nan
+        xd = x - x.mean()
+        yd = y - y.mean()
+        sxx = (xd * xd).sum()
+        if sxx <= 0:
+            return np.nan
+        return float(((xd * yd).sum()) / sxx)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, columns=list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, columns=list(self.required_pv_columns))
+        out = sample[["symbol"]].copy() if sample is not None else None
+        if full is None or sample is None:
+            return None
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(set(sample["symbol"].unique()))]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.copy()
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df["n"] = pd.to_numeric(df["n"], errors="coerce")
+        df = df.dropna(subset=["close", "n"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.sort_index()
+        value = df.groupby("symbol").apply(
+            lambda g: self._ols_slope(g["n"], g["close"])
+        )
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = CloseOnNBetaFeature()

--- a/cube2mat/features/close_on_volume_beta.py
+++ b/cube2mat/features/close_on_volume_beta.py
@@ -1,0 +1,69 @@
+# features/close_on_volume_beta.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class CloseOnVolumeBetaFeature(BaseFeature):
+    """
+    09:30–15:59 内，按 symbol 做 OLS: close ~ volume，输出斜率（价格/股）。
+    若有效样本<2 或 var(volume)=0，则 NaN。
+    """
+
+    name = "close_on_volume_beta"
+    description = (
+        "OLS slope of close on volume within 09:30–15:59; NaN if insufficient or var(volume)=0."
+    )
+    required_full_columns = ("symbol", "time", "close", "volume")
+    required_pv_columns = ("symbol",)
+
+    @staticmethod
+    def _ols_slope(x: pd.Series, y: pd.Series) -> float:
+        n = len(x)
+        if n < 2:
+            return np.nan
+        xm = x.mean()
+        ym = y.mean()
+        xd = x - xm
+        yd = y - ym
+        sxx = (xd * xd).sum()
+        if not np.isfinite(sxx) or sxx <= 0:
+            return np.nan
+        sxy = (xd * yd).sum()
+        return float(sxy / sxx)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, columns=list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, columns=list(self.required_pv_columns))
+        out = sample[["symbol"]].copy() if sample is not None else None
+        if full is None or sample is None:
+            return None
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(set(sample["symbol"].unique()))]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.copy()
+        for c in ("close", "volume"):
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+        df = df.dropna(subset=["close", "volume"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.sort_index()
+        value = df.groupby("symbol").apply(
+            lambda g: self._ols_slope(g["volume"], g["close"])
+        )
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = CloseOnVolumeBetaFeature()

--- a/cube2mat/features/corr_close_n.py
+++ b/cube2mat/features/corr_close_n.py
@@ -1,0 +1,64 @@
+# features/corr_close_n.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class CorrCloseNFeature(BaseFeature):
+    """
+    09:30–15:59 内，Pearson 相关：corr(close, n)。
+    若样本<2 或方差为 0，则 NaN。
+    """
+
+    name = "corr_close_n"
+    description = "Pearson correlation between close and n within 09:30–15:59."
+    required_full_columns = ("symbol", "time", "close", "n")
+    required_pv_columns = ("symbol",)
+
+    @staticmethod
+    def _pearson_corr(x: pd.Series, y: pd.Series) -> float:
+        n = len(x)
+        if n < 2:
+            return np.nan
+        xd = x - x.mean()
+        yd = y - y.mean()
+        sxx = (xd * xd).sum()
+        syy = (yd * yd).sum()
+        if sxx <= 0 or syy <= 0:
+            return np.nan
+        return float((xd * yd).sum() / np.sqrt(sxx * syy))
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, columns=list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, columns=list(self.required_pv_columns))
+        out = sample[["symbol"]].copy() if sample is not None else None
+        if full is None or sample is None:
+            return None
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(set(sample["symbol"].unique()))]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.copy()
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df["n"] = pd.to_numeric(df["n"], errors="coerce")
+        df = df.dropna(subset=["close", "n"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        value = df.sort_index().groupby("symbol").apply(
+            lambda g: self._pearson_corr(g["close"], g["n"])
+        )
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = CorrCloseNFeature()

--- a/cube2mat/features/corr_close_volume.py
+++ b/cube2mat/features/corr_close_volume.py
@@ -1,0 +1,66 @@
+# features/corr_close_volume.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class CorrCloseVolumeFeature(BaseFeature):
+    """
+    09:30–15:59 内，Pearson 相关：corr(close, volume)。
+    若样本<2 或方差为 0，则 NaN。
+    """
+
+    name = "corr_close_volume"
+    description = "Pearson correlation between close and volume within 09:30–15:59."
+    required_full_columns = ("symbol", "time", "close", "volume")
+    required_pv_columns = ("symbol",)
+
+    @staticmethod
+    def _pearson_corr(x: pd.Series, y: pd.Series) -> float:
+        n = len(x)
+        if n < 2:
+            return np.nan
+        xd = x - x.mean()
+        yd = y - y.mean()
+        sxx = (xd * xd).sum()
+        syy = (yd * yd).sum()
+        if sxx <= 0 or syy <= 0:
+            return np.nan
+        r = (xd * yd).sum() / np.sqrt(sxx * syy)
+        return float(r)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, columns=list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, columns=list(self.required_pv_columns))
+        out = sample[["symbol"]].copy() if sample is not None else None
+        if full is None or sample is None:
+            return None
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(set(sample["symbol"].unique()))]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.copy()
+        for c in ("close", "volume"):
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+        df = df.dropna(subset=["close", "volume"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.sort_index()
+        value = df.groupby("symbol").apply(
+            lambda g: self._pearson_corr(g["close"], g["volume"])
+        )
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = CorrCloseVolumeFeature()

--- a/cube2mat/features/diff_close_vwap_on_n_beta.py
+++ b/cube2mat/features/diff_close_vwap_on_n_beta.py
@@ -1,0 +1,65 @@
+# features/diff_close_vwap_on_n_beta.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class DiffCloseVwapOnNBetaFeature(BaseFeature):
+    """
+    09:30–15:59 内，OLS: (close - vwap) ~ n，输出斜率。
+    捕捉价差溢价与成交笔数的关系。样本<2 或 var(n)=0 则 NaN。
+    """
+
+    name = "diff_close_vwap_on_n_beta"
+    description = "OLS slope of (close - vwap) on n within 09:30–15:59."
+    required_full_columns = ("symbol", "time", "close", "vwap", "n")
+    required_pv_columns = ("symbol",)
+
+    @staticmethod
+    def _ols_slope(x: pd.Series, y: pd.Series) -> float:
+        if len(x) < 2:
+            return np.nan
+        xd = x - x.mean()
+        yd = y - y.mean()
+        sxx = (xd * xd).sum()
+        if sxx <= 0:
+            return np.nan
+        return float(((xd * yd).sum()) / sxx)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, columns=list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, columns=list(self.required_pv_columns))
+        out = sample[["symbol"]].copy() if sample is not None else None
+
+        if full is None or sample is None:
+            return None
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(set(sample["symbol"].unique()))]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.copy()
+        for c in ("close", "vwap", "n"):
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+        df = df.dropna(subset=["close", "vwap", "n"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["diff"] = df["close"] - df["vwap"]
+        df = df.sort_index()
+        value = df.groupby("symbol").apply(
+            lambda g: self._ols_slope(g["n"], g["diff"])
+        )
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = DiffCloseVwapOnNBetaFeature()

--- a/cube2mat/features/diff_close_vwap_on_volume_beta.py
+++ b/cube2mat/features/diff_close_vwap_on_volume_beta.py
@@ -1,0 +1,65 @@
+# features/diff_close_vwap_on_volume_beta.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class DiffCloseVwapOnVolumeBetaFeature(BaseFeature):
+    """
+    09:30–15:59 内，OLS: (close - vwap) ~ volume，输出斜率。
+    捕捉价差溢价对成交量的日内敏感度。样本<2 或 var(volume)=0 则 NaN。
+    """
+
+    name = "diff_close_vwap_on_volume_beta"
+    description = "OLS slope of (close - vwap) on volume within 09:30–15:59."
+    required_full_columns = ("symbol", "time", "close", "vwap", "volume")
+    required_pv_columns = ("symbol",)
+
+    @staticmethod
+    def _ols_slope(x: pd.Series, y: pd.Series) -> float:
+        n = len(x)
+        if n < 2:
+            return np.nan
+        xd = x - x.mean()
+        yd = y - y.mean()
+        sxx = (xd * xd).sum()
+        if sxx <= 0:
+            return np.nan
+        return float(((xd * yd).sum()) / sxx)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, columns=list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, columns=list(self.required_pv_columns))
+        out = sample[["symbol"]].copy() if sample is not None else None
+        if full is None or sample is None:
+            return None
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(set(sample["symbol"].unique()))]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.copy()
+        for c in ("close", "vwap", "volume"):
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+        df = df.dropna(subset=["close", "vwap", "volume"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["diff"] = df["close"] - df["vwap"]
+        df = df.sort_index()
+        value = df.groupby("symbol").apply(
+            lambda g: self._ols_slope(g["volume"], g["diff"])
+        )
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = DiffCloseVwapOnVolumeBetaFeature()

--- a/cube2mat/features/partial_corr_close_n_time.py
+++ b/cube2mat/features/partial_corr_close_n_time.py
@@ -1,0 +1,86 @@
+# features/partial_corr_close_n_time.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class PartialCorrCloseNTimeFeature(BaseFeature):
+    """
+    09:30–15:59 内，控制时间(分钟)后的偏相关：
+      resid_close = close ~ time 的残差
+      resid_n     = n     ~ time 的残差
+      value = corr(resid_close, resid_n)
+    若无足够样本或去趋势方差为 0，则 NaN。
+    """
+
+    name = "partial_corr_close_n_time"
+    description = "Partial correlation between close and n controlling for time within 09:30–15:59."
+    required_full_columns = ("symbol", "time", "close", "n")
+    required_pv_columns = ("symbol",)
+
+    @staticmethod
+    def _residual_against_time(z: pd.Series, t: pd.Series) -> pd.Series | None:
+        if len(z) < 2:
+            return None
+        zm, tm = z.mean(), t.mean()
+        zd, td = z - zm, t - tm
+        sxx = (td * td).sum()
+        if sxx <= 0:
+            return None
+        beta1 = (td * zd).sum() / sxx
+        beta0 = zm - beta1 * tm
+        return z - (beta0 + beta1 * t)
+
+    @staticmethod
+    def _pearson_corr(x: pd.Series, y: pd.Series) -> float:
+        xd = x - x.mean()
+        yd = y - y.mean()
+        sxx = (xd * xd).sum()
+        syy = (yd * yd).sum()
+        if sxx <= 0 or syy <= 0:
+            return np.nan
+        return float((xd * yd).sum() / np.sqrt(sxx * syy))
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, columns=list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, columns=list(self.required_pv_columns))
+        out = sample[["symbol"]].copy() if sample is not None else None
+        if full is None or sample is None:
+            return None
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(set(sample["symbol"].unique()))]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.copy()
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df["n"] = pd.to_numeric(df["n"], errors="coerce")
+        df = df.dropna(subset=["close", "n"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.sort_index()
+        tdelta = (df.index - df.index.normalize()) - pd.Timedelta("09:30:00")
+        df["t_min"] = tdelta.total_seconds() / 60.0
+
+        def per_symbol(g: pd.DataFrame) -> float:
+            rc = self._residual_against_time(g["close"], g["t_min"])
+            rn = self._residual_against_time(g["n"], g["t_min"])
+            if rc is None or rn is None:
+                return np.nan
+            return self._pearson_corr(rc, rn)
+
+        value = df.groupby("symbol").apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = PartialCorrCloseNTimeFeature()

--- a/cube2mat/features/partial_corr_close_volume_time.py
+++ b/cube2mat/features/partial_corr_close_volume_time.py
@@ -1,0 +1,88 @@
+# features/partial_corr_close_volume_time.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class PartialCorrCloseVolumeTimeFeature(BaseFeature):
+    """
+    09:30–15:59 内，控制时间(分钟)后的偏相关：
+      将 close 与 volume 分别对 time(分钟)做 OLS 回归，取残差，
+      然后计算 Pearson corr(resid_close, resid_volume)。
+    n<3 或去趋势方差为 0 时 NaN。
+    """
+
+    name = "partial_corr_close_volume_time"
+    description = "Partial correlation between close and volume controlling for time within 09:30–15:59."
+    required_full_columns = ("symbol", "time", "close", "volume")
+    required_pv_columns = ("symbol",)
+
+    @staticmethod
+    def _residual_against_time(z: pd.Series, t: pd.Series) -> pd.Series | None:
+        n = len(z)
+        if n < 2:
+            return None
+        zm = z.mean()
+        tm = t.mean()
+        zd = z - zm
+        td = t - tm
+        sxx = (td * td).sum()
+        if sxx <= 0:
+            return None
+        beta1 = (td * zd).sum() / sxx
+        beta0 = zm - beta1 * tm
+        return z - (beta0 + beta1 * t)
+
+    @staticmethod
+    def _pearson_corr(x: pd.Series, y: pd.Series) -> float:
+        xd = x - x.mean()
+        yd = y - y.mean()
+        sxx = (xd * xd).sum()
+        syy = (yd * yd).sum()
+        if sxx <= 0 or syy <= 0:
+            return np.nan
+        return float((xd * yd).sum() / np.sqrt(sxx * syy))
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, columns=list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, columns=list(self.required_pv_columns))
+        out = sample[["symbol"]].copy() if sample is not None else None
+        if full is None or sample is None:
+            return None
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(set(sample["symbol"].unique()))]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.copy()
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df["volume"] = pd.to_numeric(df["volume"], errors="coerce")
+        df = df.dropna(subset=["close", "volume"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.sort_index()
+        tdelta = (df.index - df.index.normalize()) - pd.Timedelta("09:30:00")
+        df["t_min"] = tdelta.total_seconds() / 60.0
+
+        def per_symbol(g: pd.DataFrame) -> float:
+            rc = self._residual_against_time(g["close"], g["t_min"])
+            rv = self._residual_against_time(g["volume"], g["t_min"])
+            if rc is None or rv is None:
+                return np.nan
+            return self._pearson_corr(rc, rv)
+
+        value = df.groupby("symbol").apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = PartialCorrCloseVolumeTimeFeature()

--- a/cube2mat/features/relprice_log_elasticity_n.py
+++ b/cube2mat/features/relprice_log_elasticity_n.py
@@ -1,0 +1,80 @@
+# features/relprice_log_elasticity_n.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class RelPriceLogElasticityNFeature(BaseFeature):
+    """
+    09:30–15:59 内，弹性回归：log(close/anchor) ~ log(n)，anchor=首笔 open（若无则首笔 close）。
+    仅使用 close>0 且 n>0 的样本。返回斜率（对数弹性）。
+    若有效样本<2 或 var(log(n))=0，则 NaN。
+    """
+
+    name = "relprice_log_elasticity_n"
+    description = "Elasticity: slope of log(close/anchor) on log(n) within 09:30–15:59."
+    required_full_columns = ("symbol", "time", "open", "close", "n")
+    required_pv_columns = ("symbol",)
+
+    @staticmethod
+    def _ols_slope(x: pd.Series, y: pd.Series) -> float:
+        if len(x) < 2:
+            return np.nan
+        xd = x - x.mean()
+        yd = y - y.mean()
+        sxx = (xd * xd).sum()
+        if sxx <= 0:
+            return np.nan
+        return float(((xd * yd).sum()) / sxx)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, columns=list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, columns=list(self.required_pv_columns))
+        out = sample[["symbol"]].copy() if sample is not None else None
+
+        if full is None or sample is None:
+            return None
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(set(sample["symbol"].unique()))]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.copy()
+        for c in ("open", "close", "n"):
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+        df = df.dropna(subset=["close", "n"])
+        df = df[(df["close"] > 0) & (df["n"] > 0)]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.sort_index()
+
+        def per_symbol(g: pd.DataFrame) -> float:
+            first_open = g["open"].dropna()
+            anchor = first_open.iloc[0] if not first_open.empty else g["close"].iloc[0]
+            if not np.isfinite(anchor) or anchor <= 0:
+                return np.nan
+            y = np.log(g["close"]) - np.log(anchor)
+            x = np.log(g["n"])
+            mask = (
+                y.replace([np.inf, -np.inf], np.nan).notna()
+                & x.replace([np.inf, -np.inf], np.nan).notna()
+            )
+            if mask.sum() < 2:
+                return np.nan
+            return self._ols_slope(x[mask], y[mask])
+
+        value = df.groupby("symbol").apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = RelPriceLogElasticityNFeature()

--- a/cube2mat/features/relprice_log_elasticity_volume.py
+++ b/cube2mat/features/relprice_log_elasticity_volume.py
@@ -1,0 +1,81 @@
+# features/relprice_log_elasticity_volume.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class RelPriceLogElasticityVolumeFeature(BaseFeature):
+    """
+    09:30–15:59 内，弹性回归：log(close/anchor) ~ log(volume)，anchor=首笔 open（若无则首笔 close）。
+    仅使用 close>0 且 volume>0 的样本。返回斜率（对数弹性）。
+    若有效样本<2 或 var(log(volume))=0，则 NaN。
+    """
+
+    name = "relprice_log_elasticity_volume"
+    description = "Elasticity: slope of log(close/anchor) on log(volume) within 09:30–15:59."
+    required_full_columns = ("symbol", "time", "open", "close", "volume")
+    required_pv_columns = ("symbol",)
+
+    @staticmethod
+    def _ols_slope(x: pd.Series, y: pd.Series) -> float:
+        if len(x) < 2:
+            return np.nan
+        xd = x - x.mean()
+        yd = y - y.mean()
+        sxx = (xd * xd).sum()
+        if sxx <= 0:
+            return np.nan
+        return float(((xd * yd).sum()) / sxx)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, columns=list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, columns=list(self.required_pv_columns))
+        out = sample[["symbol"]].copy() if sample is not None else None
+
+        if full is None or sample is None:
+            return None
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(set(sample["symbol"].unique()))]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.copy()
+        for c in ("open", "close", "volume"):
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+        df = df.dropna(subset=["close", "volume"])
+        df = df[df["close"] > 0]
+        df = df[df["volume"] > 0]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.sort_index()
+
+        def per_symbol(g: pd.DataFrame) -> float:
+            first_open = g["open"].dropna()
+            anchor = first_open.iloc[0] if not first_open.empty else g["close"].iloc[0]
+            if not np.isfinite(anchor) or anchor <= 0:
+                return np.nan
+            y = np.log(g["close"]) - np.log(anchor)
+            x = np.log(g["volume"])
+            mask = (
+                y.replace([np.inf, -np.inf], np.nan).notna()
+                & x.replace([np.inf, -np.inf], np.nan).notna()
+            )
+            if mask.sum() < 2:
+                return np.nan
+            return self._ols_slope(x[mask], y[mask])
+
+        value = df.groupby("symbol").apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = RelPriceLogElasticityVolumeFeature()

--- a/cube2mat/features/spearman_close_n.py
+++ b/cube2mat/features/spearman_close_n.py
@@ -1,0 +1,66 @@
+# features/spearman_close_n.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class SpearmanCloseNFeature(BaseFeature):
+    """
+    09:30–15:59 内，Spearman 等级相关：corr(rank(close), rank(n))。
+    若有效样本<2 或秩方差为 0，则 NaN。
+    """
+
+    name = "spearman_close_n"
+    description = "Spearman rank correlation between close and n within 09:30–15:59."
+    required_full_columns = ("symbol", "time", "close", "n")
+    required_pv_columns = ("symbol",)
+
+    @staticmethod
+    def _pearson_corr(x: pd.Series, y: pd.Series) -> float:
+        xd = x - x.mean()
+        yd = y - y.mean()
+        sxx = (xd * xd).sum()
+        syy = (yd * yd).sum()
+        if sxx <= 0 or syy <= 0:
+            return np.nan
+        return float((xd * yd).sum() / np.sqrt(sxx * syy))
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, columns=list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, columns=list(self.required_pv_columns))
+        out = sample[["symbol"]].copy() if sample is not None else None
+        if full is None or sample is None:
+            return None
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(set(sample["symbol"].unique()))]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.copy()
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df["n"] = pd.to_numeric(df["n"], errors="coerce")
+        df = df.dropna(subset=["close", "n"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        def per_symbol(g: pd.DataFrame) -> float:
+            if len(g) < 2:
+                return np.nan
+            rc = g["close"].rank(method="average")
+            rn = g["n"].rank(method="average")
+            return self._pearson_corr(rc, rn)
+
+        value = df.sort_index().groupby("symbol").apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = SpearmanCloseNFeature()

--- a/cube2mat/features/spearman_close_volume.py
+++ b/cube2mat/features/spearman_close_volume.py
@@ -1,0 +1,66 @@
+# features/spearman_close_volume.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class SpearmanCloseVolumeFeature(BaseFeature):
+    """
+    09:30–15:59 内，Spearman 等级相关：corr(rank(close), rank(volume))。
+    若有效样本<2 或全同值导致秩方差为 0，则 NaN。
+    """
+
+    name = "spearman_close_volume"
+    description = "Spearman rank correlation between close and volume within 09:30–15:59."
+    required_full_columns = ("symbol", "time", "close", "volume")
+    required_pv_columns = ("symbol",)
+
+    @staticmethod
+    def _pearson_corr(x: pd.Series, y: pd.Series) -> float:
+        xd = x - x.mean()
+        yd = y - y.mean()
+        sxx = (xd * xd).sum()
+        syy = (yd * yd).sum()
+        if sxx <= 0 or syy <= 0:
+            return np.nan
+        return float((xd * yd).sum() / np.sqrt(sxx * syy))
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, columns=list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, columns=list(self.required_pv_columns))
+        out = sample[["symbol"]].copy() if sample is not None else None
+        if full is None or sample is None:
+            return None
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(set(sample["symbol"].unique()))]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.copy()
+        for c in ("close", "volume"):
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+        df = df.dropna(subset=["close", "volume"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        def per_symbol(g: pd.DataFrame) -> float:
+            if len(g) < 2:
+                return np.nan
+            rc = g["close"].rank(method="average")
+            rv = g["volume"].rank(method="average")
+            return self._pearson_corr(rc, rv)
+
+        value = df.sort_index().groupby("symbol").apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = SpearmanCloseVolumeFeature()


### PR DESCRIPTION
## Summary
- add OLS slope features for close vs volume and trade count (linear and log variants)
- add Pearson and Spearman correlation features between close and volume/n
- add partial correlation, VWAP spread beta, and relative price log elasticity features

## Testing
- `python -m py_compile cube2mat/features/*.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a130db1e6c832aa3e932d4a5603868