### PR TITLE
Add intraday clustering features with normalized time outputs

### DIFF
--- a/cube2mat/features/absret_peak_time_min.py
+++ b/cube2mat/features/absret_peak_time_min.py
@@ -1,0 +1,73 @@
+# features/absret_peak_time_min.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class AbsRetPeakTimeMinFeature(BaseFeature):
+    """
+    |ret| 峰值出现时间占全日交易时长的比例（自 09:30 起），ret=close.pct_change()；若无有效 ret 则 NaN。
+    """
+
+    name = "absret_peak_time_min"
+    description = "Fraction of trading session elapsed when |ret| reaches its maximum."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    TOTAL_MIN = (
+        pd.Timedelta("15:59:00") - pd.Timedelta("09:30:00")
+    ).total_seconds() / 60.0
+
+    @staticmethod
+    def _minutes_since_open(ts: pd.Timestamp) -> float:
+        td = (
+            ts - ts.normalize() - pd.Timedelta("09:30:00")
+        ).total_seconds() / 60.0
+        return float(td)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.copy()
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.sort_index()
+        df["ret"] = df.groupby("symbol", sort=False)["close"].pct_change()
+        df["ret"] = df["ret"].replace([np.inf, -np.inf], np.nan)
+        df["absret"] = df["ret"].abs()
+        df = df.dropna(subset=["absret"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        def per_symbol(g: pd.DataFrame) -> float:
+            idx = g["absret"].idxmax()
+            if pd.isna(idx):
+                return np.nan
+            return self._minutes_since_open(idx) / self.TOTAL_MIN
+
+        value = df.groupby("symbol").apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = AbsRetPeakTimeMinFeature()

--- a/cube2mat/features/ac1_n.py
+++ b/cube2mat/features/ac1_n.py
@@ -1,0 +1,62 @@
+# features/ac1_n.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class AC1NFeature(BaseFeature):
+    """
+    09:30–15:59 内，成交笔数的 lag-1 自相关。
+    """
+
+    name = "ac1_n"
+    description = "Lag-1 autocorrelation of trade counts n across intraday bars."
+    required_full_columns = ("symbol", "time", "n")
+    required_pv_columns = ("symbol",)
+
+    @staticmethod
+    def _ac1(x: pd.Series) -> float:
+        if len(x) < 2:
+            return np.nan
+        x = x.astype(float)
+        x0 = x.iloc[:-1]
+        x1 = x.iloc[1:]
+        xd0 = x0 - x0.mean()
+        xd1 = x1 - x1.mean()
+        s00 = (xd0 * xd0).sum()
+        s11 = (xd1 * xd1).sum()
+        if s00 <= 0 or s11 <= 0:
+            return np.nan
+        return float((xd0 * xd1).sum() / np.sqrt(s00 * s11))
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.copy()
+        df["n"] = pd.to_numeric(df["n"], errors="coerce")
+        df = df.dropna(subset=["n"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        value = df.sort_index().groupby("symbol")["n"].apply(self._ac1)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = AC1NFeature()

--- a/cube2mat/features/ac1_volume.py
+++ b/cube2mat/features/ac1_volume.py
@@ -1,0 +1,62 @@
+# features/ac1_volume.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class AC1VolumeFeature(BaseFeature):
+    """
+    09:30–15:59 内，成交量的 lag-1 皮尔逊自相关；len<2 或方差为 0 则 NaN。
+    """
+
+    name = "ac1_volume"
+    description = "Lag-1 autocorrelation of volume across intraday bars."
+    required_full_columns = ("symbol", "time", "volume")
+    required_pv_columns = ("symbol",)
+
+    @staticmethod
+    def _ac1(x: pd.Series) -> float:
+        if len(x) < 2:
+            return np.nan
+        x = x.astype(float)
+        x0 = x.iloc[:-1]
+        x1 = x.iloc[1:]
+        xd0 = x0 - x0.mean()
+        xd1 = x1 - x1.mean()
+        s00 = (xd0 * xd0).sum()
+        s11 = (xd1 * xd1).sum()
+        if s00 <= 0 or s11 <= 0:
+            return np.nan
+        return float((xd0 * xd1).sum() / np.sqrt(s00 * s11))
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.copy()
+        df["volume"] = pd.to_numeric(df["volume"], errors="coerce")
+        df = df.dropna(subset=["volume"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        value = df.sort_index().groupby("symbol")["volume"].apply(self._ac1)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = AC1VolumeFeature()

--- a/cube2mat/features/close_15m_absret_share.py
+++ b/cube2mat/features/close_15m_absret_share.py
@@ -1,0 +1,68 @@
+# features/close_15m_absret_share.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class Close15mAbsRetShareFeature(BaseFeature):
+    """
+    09:30–15:59 内，收盘 15 分钟的绝对收益贡献占比。
+    """
+
+    name = "close_15m_absret_share"
+    description = "Share of absolute returns in last 15 minutes; ret by close.pct_change."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+    TOTAL_MIN = (
+        pd.Timedelta("15:59:00") - pd.Timedelta("09:30:00")
+    ).total_seconds() / 60.0
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.copy()
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.sort_index()
+        df["ret"] = df.groupby("symbol", sort=False)["close"].pct_change()
+        df["ret"] = df["ret"].replace([np.inf, -np.inf], np.nan)
+        df = df.dropna(subset=["ret"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        tmin = (
+            df.index - df.index.normalize() - pd.Timedelta("09:30:00")
+        ).total_seconds() / 60.0
+        df["t_min"] = tmin
+        g = df.groupby("symbol")
+        denom = g["ret"].apply(lambda s: s.abs().sum())
+        num = g.apply(
+            lambda x: x.loc[x["t_min"] >= (self.TOTAL_MIN - 15.0), "ret"].abs().sum()
+        )
+        share = (num / denom).where(denom > 0)
+
+        out["value"] = out["symbol"].map(share)
+        return out
+
+
+feature = Close15mAbsRetShareFeature()

--- a/cube2mat/features/close_15m_volume_share.py
+++ b/cube2mat/features/close_15m_volume_share.py
@@ -1,0 +1,64 @@
+# features/close_15m_volume_share.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class Close15mVolumeShareFeature(BaseFeature):
+    """
+    09:30–15:59 内，收盘前 15 分钟 (t_min >= total_minutes-15) 的成交量占比。
+    若全日有效 volume 总和<=0，则 NaN。
+    """
+
+    name = "close_15m_volume_share"
+    description = "Share of volume in last 15 minutes."
+    required_full_columns = ("symbol", "time", "volume")
+    required_pv_columns = ("symbol",)
+
+    TOTAL_MIN = (
+        pd.Timedelta("15:59:00") - pd.Timedelta("09:30:00")
+    ).total_seconds() / 60.0  # = 389
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.copy()
+        df["volume"] = pd.to_numeric(df["volume"], errors="coerce")
+        df = df.dropna(subset=["volume"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.sort_index()
+        tmin = (
+            df.index - df.index.normalize() - pd.Timedelta("09:30:00")
+        ).total_seconds() / 60.0
+        df["t_min"] = tmin
+
+        g = df.groupby("symbol")
+        total = g["volume"].sum()
+        close15 = g.apply(
+            lambda x: x.loc[x["t_min"] >= (self.TOTAL_MIN - 15.0), "volume"].sum()
+        )
+        share = (close15 / total).where(total > 0)
+
+        out["value"] = out["symbol"].map(share)
+        return out
+
+
+feature = Close15mVolumeShareFeature()

--- a/cube2mat/features/early_late_vol_ratio_30m.py
+++ b/cube2mat/features/early_late_vol_ratio_30m.py
@@ -1,0 +1,78 @@
+# features/early_late_vol_ratio_30m.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class EarlyLateVolRatio30mFeature(BaseFeature):
+    """
+    前 30 分钟 vs 后 30 分钟的收益波动比：
+      ratio = std(ret in t<30) / std(ret in t>=total_min-30)，ret=close.pct_change()。
+    两端样本的有效收益数均需≥3，否则 NaN。
+    """
+
+    name = "early_late_vol_ratio_30m"
+    description = "Std(ret) first 30m vs last 30m ratio."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    TOTAL_MIN = (
+        pd.Timedelta("15:59:00") - pd.Timedelta("09:30:00")
+    ).total_seconds() / 60.0
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.copy()
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.sort_index()
+        df["ret"] = df.groupby("symbol", sort=False)["close"].pct_change()
+        df["ret"] = df["ret"].replace([np.inf, -np.inf], np.nan)
+        df = df.dropna(subset=["ret"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        tmin = (
+            df.index - df.index.normalize() - pd.Timedelta("09:30:00")
+        ).total_seconds() / 60.0
+        df["t_min"] = tmin
+
+        def per_symbol(g: pd.DataFrame) -> float:
+            early = g.loc[g["t_min"] < 30, "ret"]
+            late = g.loc[g["t_min"] >= (self.TOTAL_MIN - 30.0), "ret"]
+            n1, n2 = early.count(), late.count()
+            if n1 < 3 or n2 < 3:
+                return np.nan
+            s1 = early.std(ddof=1)
+            s2 = late.std(ddof=1)
+            if not np.isfinite(s1) or not np.isfinite(s2) or s2 == 0:
+                return np.nan
+            return float(s1 / s2)
+
+        value = df.groupby("symbol").apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = EarlyLateVolRatio30mFeature()

--- a/cube2mat/features/n_burstiness.py
+++ b/cube2mat/features/n_burstiness.py
@@ -1,0 +1,56 @@
+# features/n_burstiness.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class NBurstinessFeature(BaseFeature):
+    """
+    09:30–15:59 内，成交笔数的 Burstiness 指数：
+      B = (sigma - mu) / (sigma + mu)，mu>0 且 sigma>0 才有效；范围(-1,1)。
+    """
+
+    name = "n_burstiness"
+    description = "Burstiness of trade counts n across intraday bars: (std-mean)/(std+mean)."
+    required_full_columns = ("symbol", "time", "n")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.copy()
+        df["n"] = pd.to_numeric(df["n"], errors="coerce")
+        df = df.dropna(subset=["n"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        def per_symbol(g: pd.DataFrame) -> float:
+            x = g["n"].astype(float)
+            mu = x.mean()
+            sd = x.std(ddof=1) if len(x) >= 2 else np.nan
+            if not np.isfinite(mu) or not np.isfinite(sd) or mu <= 0 or sd <= 0:
+                return np.nan
+            return float((sd - mu) / (sd + mu))
+
+        value = df.groupby("symbol").apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = NBurstinessFeature()

--- a/cube2mat/features/n_fano_factor.py
+++ b/cube2mat/features/n_fano_factor.py
@@ -1,0 +1,56 @@
+# features/n_fano_factor.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class NFanoFactorFeature(BaseFeature):
+    """
+    09:30–15:59 内，成交笔数的 Fano 因子：var(n) / mean(n)；mean>0 才有效。
+    衡量过离散/聚集程度（泊松过程下约等于 1）。
+    """
+
+    name = "n_fano_factor"
+    description = "Fano factor of n across intraday bars: Var(n)/Mean(n)."
+    required_full_columns = ("symbol", "time", "n")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.copy()
+        df["n"] = pd.to_numeric(df["n"], errors="coerce")
+        df = df.dropna(subset=["n"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        def per_symbol(g: pd.DataFrame) -> float:
+            x = g["n"].astype(float)
+            mu = x.mean()
+            var = x.var(ddof=1) if len(x) >= 2 else np.nan
+            if not np.isfinite(mu) or not np.isfinite(var) or mu <= 0:
+                return np.nan
+            return float(var / mu)
+
+        value = df.groupby("symbol").apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = NFanoFactorFeature()

--- a/cube2mat/features/n_hhi.py
+++ b/cube2mat/features/n_hhi.py
@@ -1,0 +1,54 @@
+# features/n_hhi.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class NHhIFeature(BaseFeature):
+    """
+    09:30–15:59 内，成交笔数分布 HHI：sum_i ( (n_i / sum n)^2 )。
+    """
+
+    name = "n_hhi"
+    description = "Herfindahl index of trade count (n) distribution across intraday bars."
+    required_full_columns = ("symbol", "time", "n")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.copy()
+        df["n"] = pd.to_numeric(df["n"], errors="coerce")
+        df = df.dropna(subset=["n"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        def per_symbol(g: pd.DataFrame) -> float:
+            tot = g["n"].sum()
+            if not np.isfinite(tot) or tot <= 0:
+                return np.nan
+            p = g["n"] / tot
+            return float((p * p).sum())
+
+        value = df.groupby("symbol").apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = NHhIFeature()

--- a/cube2mat/features/open_15m_absret_share.py
+++ b/cube2mat/features/open_15m_absret_share.py
@@ -1,0 +1,66 @@
+# features/open_15m_absret_share.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class Open15mAbsRetShareFeature(BaseFeature):
+    """
+    09:30–15:59 内，开盘 15 分钟的绝对收益贡献占比：
+      share = sum(|ret| in t<15) / sum(|ret| all), ret=close.pct_change()。
+    若全日有效 ret 为空或分母为 0，则 NaN。
+    """
+
+    name = "open_15m_absret_share"
+    description = "Share of absolute returns in first 15 minutes; ret by close.pct_change."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.copy()
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.sort_index()
+        # ret
+        df["ret"] = df.groupby("symbol", sort=False)["close"].pct_change()
+        df["ret"] = df["ret"].replace([np.inf, -np.inf], np.nan)
+        df = df.dropna(subset=["ret"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        tmin = (
+            df.index - df.index.normalize() - pd.Timedelta("09:30:00")
+        ).total_seconds() / 60.0
+        df["t_min"] = tmin
+        g = df.groupby("symbol")
+        denom = g["ret"].apply(lambda s: s.abs().sum())
+        num = g.apply(lambda x: x.loc[x["t_min"] < 15, "ret"].abs().sum())
+        share = (num / denom).where(denom > 0)
+
+        out["value"] = out["symbol"].map(share)
+        return out
+
+
+feature = Open15mAbsRetShareFeature()

--- a/cube2mat/features/open_15m_volume_share.py
+++ b/cube2mat/features/open_15m_volume_share.py
@@ -1,0 +1,59 @@
+# features/open_15m_volume_share.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class Open15mVolumeShareFeature(BaseFeature):
+    """
+    09:30–15:59 内，开盘前 15 分钟 (t_min<15) 的成交量占比：sum(volume_open_15) / sum(volume_all)。
+    若全日有效 volume 总和<=0，则 NaN。
+    """
+
+    name = "open_15m_volume_share"
+    description = "Share of volume in first 15 minutes; sum(vol in t<15) / sum(vol all)."
+    required_full_columns = ("symbol", "time", "volume")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.copy()
+        df["volume"] = pd.to_numeric(df["volume"], errors="coerce")
+        df = df.dropna(subset=["volume"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.sort_index()
+        tmin = (
+            df.index - df.index.normalize() - pd.Timedelta("09:30:00")
+        ).total_seconds() / 60.0
+        df["t_min"] = tmin
+
+        g = df.groupby("symbol")
+        total = g["volume"].sum()
+        open15 = g.apply(lambda x: x.loc[x["t_min"] < 15, "volume"].sum())
+        share = (open15 / total).where(total > 0)
+
+        out["value"] = out["symbol"].map(share)
+        return out
+
+
+feature = Open15mVolumeShareFeature()

--- a/cube2mat/features/time_to_20pct_volume_min.py
+++ b/cube2mat/features/time_to_20pct_volume_min.py
@@ -1,0 +1,76 @@
+# features/time_to_20pct_volume_min.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class TimeTo20PctVolumeMinFeature(BaseFeature):
+    """
+    09:30–15:59 内，累积成交量达到 20% 所需时间占全日交易时长的比例（自 09:30 起）。
+    若 sum(vol)<=0 则 NaN。
+    """
+
+    name = "time_to_20pct_volume_min"
+    description = (
+        "Fraction of trading session required to reach 20% of cumulative volume."
+    )
+    required_full_columns = ("symbol", "time", "volume")
+    required_pv_columns = ("symbol",)
+
+    TOTAL_MIN = (
+        pd.Timedelta("15:59:00") - pd.Timedelta("09:30:00")
+    ).total_seconds() / 60.0
+
+    @staticmethod
+    def _minutes_since_open(idx: pd.DatetimeIndex) -> np.ndarray:
+        return (
+            (
+                idx - idx.normalize() - pd.Timedelta("09:30:00")
+            ).total_seconds()
+            / 60.0
+        ).astype(float)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.copy()
+        df["volume"] = pd.to_numeric(df["volume"], errors="coerce")
+        df = df.dropna(subset=["volume"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+        df = df.sort_index()
+
+        def per_symbol(g: pd.DataFrame) -> float:
+            v = g["volume"].astype(float)
+            tot = v.sum()
+            if not np.isfinite(tot) or tot <= 0:
+                return np.nan
+            c = v.cumsum().values
+            thr = 0.2 * tot
+            i = int(np.searchsorted(c, thr, side="left"))
+            i = min(i, len(g) - 1)
+            tmins = self._minutes_since_open(g.index)
+            return float(tmins[i] / self.TOTAL_MIN)
+
+        value = df.groupby("symbol").apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = TimeTo20PctVolumeMinFeature()

--- a/cube2mat/features/volume_entropy_concentration.py
+++ b/cube2mat/features/volume_entropy_concentration.py
@@ -1,0 +1,67 @@
+# features/volume_entropy_concentration.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class VolumeEntropyConcentrationFeature(BaseFeature):
+    """
+    09:30–15:59 内，成交量的“1-归一化熵”：
+      p_i = vol_i / sum vol；H = -sum p_i log p_i；H_norm = H / log(N)；value = 1 - H_norm。
+    越接近 1 表示越集中；若 sum(vol)<=0 或 N<2，则 NaN。
+    """
+
+    name = "volume_entropy_concentration"
+    description = (
+        "1 - normalized Shannon entropy of volume distribution across intraday bars."
+    )
+    required_full_columns = ("symbol", "time", "volume")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.copy()
+        df["volume"] = pd.to_numeric(df["volume"], errors="coerce")
+        df = df.dropna(subset=["volume"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        def per_symbol(g: pd.DataFrame) -> float:
+            N = len(g)
+            tot = g["volume"].sum()
+            if N < 2 or not np.isfinite(tot) or tot <= 0:
+                return np.nan
+            p = (g["volume"] / tot).values
+            # 过滤 p_i=0 的项（0*log0 视为 0）
+            p = p[p > 0]
+            if len(p) == 0:
+                return np.nan
+            H = -(p * np.log(p)).sum()
+            H_norm = H / np.log(N)
+            if not np.isfinite(H_norm) or H_norm < 0:
+                return np.nan
+            return float(1.0 - min(1.0, H_norm))
+
+        value = df.groupby("symbol").apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = VolumeEntropyConcentrationFeature()

--- a/cube2mat/features/volume_front_loading_score.py
+++ b/cube2mat/features/volume_front_loading_score.py
@@ -1,0 +1,83 @@
+# features/volume_front_loading_score.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class VolumeFrontLoadingScoreFeature(BaseFeature):
+    """
+    前置/后置成交量偏移得分（-1~+1）：
+      以时间归一化 tau∈[0,1] 与累积量份额 c(tau) 构成曲线，计算 AUC = ∫ c d tau（梯形法），
+      score = 2*AUC - 1。>0 前置（早段更快累积），<0 后置。
+    若 sum(vol)<=0 或样本<2，则 NaN。
+    """
+
+    name = "volume_front_loading_score"
+    description = "2*AUC(cumVolFraction vs timeFraction) - 1; positive=front-loaded."
+    required_full_columns = ("symbol", "time", "volume")
+    required_pv_columns = ("symbol",)
+
+    TOTAL_MIN = (
+        pd.Timedelta("15:59:00") - pd.Timedelta("09:30:00")
+    ).total_seconds() / 60.0
+
+    @staticmethod
+    def _tau_minutes(idx: pd.DatetimeIndex) -> np.ndarray:
+        tmin = (
+            idx - idx.normalize() - pd.Timedelta("09:30:00")
+        ).total_seconds() / 60.0
+        return tmin
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.copy()
+        df["volume"] = pd.to_numeric(df["volume"], errors="coerce")
+        df = df.dropna(subset=["volume"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.sort_index()
+
+        def per_symbol(g: pd.DataFrame) -> float:
+            v = g["volume"].astype(float).values
+            tot = v.sum()
+            if not np.isfinite(tot) or tot <= 0 or len(v) < 2:
+                return np.nan
+            cfrac = np.cumsum(v) / tot
+            tau = self._tau_minutes(g.index) / self.TOTAL_MIN
+            # 拼接起点(0,0)与终点(1,1)进行梯形积分，避免起末缺失偏差
+            tau_ext = np.concatenate(([0.0], tau, [1.0]))
+            c_ext = np.concatenate(([0.0], cfrac, [1.0]))
+            # 去重并排序（防止时间重复）
+            order = np.argsort(tau_ext)
+            tau_ext = tau_ext[order]
+            c_ext = c_ext[order]
+            # 梯形积分
+            dtau = np.diff(tau_ext)
+            AUC = np.sum(0.5 * (c_ext[1:] + c_ext[:-1]) * dtau)
+            score = 2.0 * AUC - 1.0
+            return float(score)
+
+        value = df.groupby("symbol").apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = VolumeFrontLoadingScoreFeature()

--- a/cube2mat/features/volume_hhi.py
+++ b/cube2mat/features/volume_hhi.py
@@ -1,0 +1,55 @@
+# features/volume_hhi.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class VolumeHHIFeature(BaseFeature):
+    """
+    09:30–15:59 内，成交量 HHI = sum_i ( (vol_i / sum_j vol_j)^2 )；衡量量在时间上的集中度。
+    若 sum(vol)<=0 或无有效样本，NaN。
+    """
+
+    name = "volume_hhi"
+    description = "Herfindahl index of volume distribution across intraday bars."
+    required_full_columns = ("symbol", "time", "volume")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.copy()
+        df["volume"] = pd.to_numeric(df["volume"], errors="coerce")
+        df = df.dropna(subset=["volume"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        def per_symbol(g: pd.DataFrame) -> float:
+            tot = g["volume"].sum()
+            if not np.isfinite(tot) or tot <= 0:
+                return np.nan
+            p = g["volume"] / tot
+            return float((p * p).sum())
+
+        value = df.groupby("symbol").apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = VolumeHHIFeature()

--- a/cube2mat/features/volume_peak_time_min.py
+++ b/cube2mat/features/volume_peak_time_min.py
@@ -1,0 +1,66 @@
+# features/volume_peak_time_min.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class VolumePeakTimeMinFeature(BaseFeature):
+    """
+    成交量峰值出现时间占全日交易时长的比例（自 09:30 起）。若无有效 volume 则 NaN。
+    """
+
+    name = "volume_peak_time_min"
+    description = "Fraction of trading session elapsed when maximum per-bar volume occurs."
+    required_full_columns = ("symbol", "time", "volume")
+    required_pv_columns = ("symbol",)
+
+    TOTAL_MIN = (
+        pd.Timedelta("15:59:00") - pd.Timedelta("09:30:00")
+    ).total_seconds() / 60.0
+
+    @staticmethod
+    def _minutes_since_open(ts: pd.Timestamp) -> float:
+        td = (
+            ts - ts.normalize() - pd.Timedelta("09:30:00")
+        ).total_seconds() / 60.0
+        return float(td)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.copy()
+        df["volume"] = pd.to_numeric(df["volume"], errors="coerce")
+        df = df.dropna(subset=["volume"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.sort_index()
+
+        def per_symbol(g: pd.DataFrame) -> float:
+            idx = g["volume"].idxmax()
+            if pd.isna(idx):
+                return np.nan
+            return self._minutes_since_open(idx) / self.TOTAL_MIN
+
+        value = df.groupby("symbol").apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = VolumePeakTimeMinFeature()


### PR DESCRIPTION
## Summary
- add 16 intraday features to study volume, return, and trade count concentration around open/close and throughout the session
- normalize time-based outputs to fractions of the full 09:30–15:59 trading period

## Testing
- `python -m py_compile $(git ls-files 'cube2mat/**/*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a178050730832aa6ce82963a0caceb