### PR TITLE
Add intraday volatility and time-fraction features

### DIFF
--- a/cube2mat/features/absret_peak_time_frac.py
+++ b/cube2mat/features/absret_peak_time_frac.py
@@ -1,0 +1,71 @@
+# features/absret_peak_time_frac.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class AbsRetPeakTimeFracFeature(BaseFeature):
+    """
+    |ret| 峰值出现的“时间占比”（峰值出现的分钟 / 总分钟，∈[0,1]），ret=close.pct_change()。
+    """
+
+    name = "absret_peak_time_frac"
+    description = "Fraction of session minutes when |ret| peaks."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+    TOTAL_MIN = (
+        pd.Timedelta("15:59:00") - pd.Timedelta("09:30:00")
+    ).total_seconds() / 60.0
+
+    @staticmethod
+    def _minutes_since_open(ts: pd.Timestamp) -> float:
+        return float(
+            (ts - ts.normalize() - pd.Timedelta("09:30:00")).total_seconds() / 60.0
+        )
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"]).sort_index()
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["ret"] = df.groupby("symbol", sort=False)["close"].pct_change()
+        df["ret"] = df["ret"].replace([np.inf, -np.inf], np.nan)
+        df["absret"] = df["ret"].abs()
+        df = df.dropna(subset=["absret"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        def per_symbol(g: pd.DataFrame) -> float:
+            idx = g["absret"].idxmax()
+            if pd.isna(idx):
+                return np.nan
+            mins = self._minutes_since_open(idx)
+            return float(mins / self.TOTAL_MIN)
+
+        value = df.groupby("symbol").apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = AbsRetPeakTimeFracFeature()
+

--- a/cube2mat/features/ac1_absret.py
+++ b/cube2mat/features/ac1_absret.py
@@ -1,0 +1,70 @@
+# features/ac1_absret.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class AC1AbsRetFeature(BaseFeature):
+    """
+    09:30–15:59 内，|log 收益| 的 lag-1 皮尔逊自相关；len<2 或方差为0 则 NaN。
+    """
+
+    name = "ac1_absret"
+    description = "Lag-1 autocorrelation of |log returns| (volatility clustering)."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    @staticmethod
+    def _ac1(x: pd.Series) -> float:
+        if len(x) < 2:
+            return np.nan
+        x0 = x.iloc[:-1].astype(float)
+        x1 = x.iloc[1:].astype(float)
+        xd0 = x0 - x0.mean()
+        xd1 = x1 - x1.mean()
+        s00 = (xd0 * xd0).sum()
+        s11 = (xd1 * xd1).sum()
+        if s00 <= 0 or s11 <= 0:
+            return np.nan
+        return float((xd0 * xd1).sum() / np.sqrt(s00 * s11))
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df[(df["close"] > 0)].dropna(subset=["close"]).sort_index()
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["log_close"] = np.log(df["close"])
+        df["r"] = df.groupby("symbol", sort=False)["log_close"].diff()
+        df["r"] = df["r"].replace([np.inf, -np.inf], np.nan)
+        df = df.dropna(subset=["r"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["absr"] = df["r"].abs()
+        value = df.groupby("symbol")["absr"].apply(self._ac1)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = AC1AbsRetFeature()
+

--- a/cube2mat/features/bpv_logret.py
+++ b/cube2mat/features/bpv_logret.py
@@ -1,0 +1,61 @@
+# features/bpv_logret.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class BPVLogRetFeature(BaseFeature):
+    """
+    09:30–15:59 内，BPV = (π/2) * sum_{t>=2} |r_t||r_{t-1}|，r_t=diff(log(close))，close>0。
+    """
+
+    name = "bpv_logret"
+    description = "Bipower variation: (pi/2) * sum |r_t||r_{t-1}| using log returns."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df[(df["close"] > 0)].dropna(subset=["close"]).sort_index()
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["log_close"] = np.log(df["close"])
+        df["r"] = df.groupby("symbol", sort=False)["log_close"].diff()
+        df["r"] = df["r"].replace([np.inf, -np.inf], np.nan)
+        df = df.dropna(subset=["r"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        def per_symbol(s: pd.Series) -> float:
+            if len(s) < 2:
+                return np.nan
+            x = s.abs().values
+            return float((np.pi / 2.0) * np.sum(x[1:] * x[:-1]))
+
+        value = df.groupby("symbol")["r"].apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = BPVLogRetFeature()
+

--- a/cube2mat/features/cv_close.py
+++ b/cube2mat/features/cv_close.py
@@ -1,0 +1,51 @@
+# features/cv_close.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class CVCloseFeature(BaseFeature):
+    """
+    09:30–15:59 内，CV(close) = std(close)/mean(close)；mean<=0 或样本<2 则 NaN。
+    """
+
+    name = "cv_close"
+    description = "Coefficient of variation of close: std/mean within 09:30–15:59."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        g = df.groupby("symbol")["close"]
+        stats = g.agg(n="count", mean="mean", std=lambda s: s.std(ddof=1))
+        cv = (stats["std"] / stats["mean"]).where(
+            (stats["n"] >= 2) & (stats["mean"] > 0)
+        )
+        out["value"] = out["symbol"].map(cv)
+        return out
+
+
+feature = CVCloseFeature()
+

--- a/cube2mat/features/jump_var_bns.py
+++ b/cube2mat/features/jump_var_bns.py
@@ -1,0 +1,64 @@
+# features/jump_var_bns.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class JumpVarBNSFeature(BaseFeature):
+    """
+    09:30–15:59 内，跳跃变差估计：max(RV - BPV, 0)，r_t=diff(log(close))，close>0。
+    """
+
+    name = "jump_var_bns"
+    description = "Jump variation proxy: max(RV - BPV, 0) with log returns."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df[(df["close"] > 0)].dropna(subset=["close"]).sort_index()
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["log_close"] = np.log(df["close"])
+        df["r"] = df.groupby("symbol", sort=False)["log_close"].diff()
+        df["r"] = df["r"].replace([np.inf, -np.inf], np.nan)
+        df = df.dropna(subset=["r"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        def per_symbol(s: pd.Series) -> float:
+            r = s.values
+            if len(r) < 2:
+                return np.nan
+            rv = float(np.sum(r * r))
+            bpv = float((np.pi / 2.0) * np.sum(np.abs(r[1:]) * np.abs(r[:-1])))
+            val = rv - bpv
+            return float(val) if np.isfinite(val) and val > 0 else 0.0
+
+        value = df.groupby("symbol")["r"].apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = JumpVarBNSFeature()
+

--- a/cube2mat/features/neg_semivar_ret.py
+++ b/cube2mat/features/neg_semivar_ret.py
@@ -1,0 +1,59 @@
+# features/neg_semivar_ret.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class NegSemivarRetFeature(BaseFeature):
+    """
+    09:30–15:59 内，下行半方差：sum( r_t^2 * 1{r_t<0} )，r_t=diff(log(close))，close>0。
+    """
+
+    name = "neg_semivar_ret"
+    description = "Negative semivariance of log returns."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df[(df["close"] > 0)].dropna(subset=["close"]).sort_index()
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["log_close"] = np.log(df["close"])
+        df["r"] = df.groupby("symbol", sort=False)["log_close"].diff()
+        df["r"] = df["r"].replace([np.inf, -np.inf], np.nan)
+        df = df.dropna(subset=["r"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        def per_symbol(s: pd.Series) -> float:
+            r = s.values
+            return float(np.sum((r[r < 0]) ** 2)) if len(r) > 0 else np.nan
+
+        value = df.groupby("symbol")["r"].apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = NegSemivarRetFeature()
+

--- a/cube2mat/features/parkinson_vol.py
+++ b/cube2mat/features/parkinson_vol.py
@@ -1,0 +1,58 @@
+# features/parkinson_vol.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class ParkinsonVolFeature(BaseFeature):
+    """
+    09:30–15:59 内，汇总单日极值：H=max(high), L=min(low)，
+    Parkinson 方差：sigma2 = [ln(H/L)]^2 / (4*ln(2))；波动率 = sqrt(sigma2)。
+    需 H>0, L>0；若缺列或无效则 NaN。
+    """
+
+    name = "parkinson_vol"
+    description = "Parkinson volatility from session high/low: sqrt((ln(H/L))^2 / (4 ln 2))."
+    required_full_columns = ("symbol", "time", "high", "low")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        for c in ("high", "low"):
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+        df = df.dropna(subset=["high", "low"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        g = df.groupby("symbol")
+        H = g["high"].max()
+        L = g["low"].min()
+        valid = (H > 0) & (L > 0)
+        ratio = (H / L).where(valid)
+        lnHL = np.log(ratio)
+        sigma2 = (lnHL * lnHL) / (4.0 * np.log(2.0))
+        value = sigma2.apply(lambda x: float(np.sqrt(x)) if pd.notna(x) and x >= 0 else np.nan)
+
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = ParkinsonVolFeature()
+

--- a/cube2mat/features/pos_semivar_ret.py
+++ b/cube2mat/features/pos_semivar_ret.py
@@ -1,0 +1,59 @@
+# features/pos_semivar_ret.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class PosSemivarRetFeature(BaseFeature):
+    """
+    09:30–15:59 内，上行半方差：sum( r_t^2 * 1{r_t>0} )，r_t=diff(log(close))，close>0。
+    """
+
+    name = "pos_semivar_ret"
+    description = "Positive semivariance of log returns."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df[(df["close"] > 0)].dropna(subset=["close"]).sort_index()
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["log_close"] = np.log(df["close"])
+        df["r"] = df.groupby("symbol", sort=False)["log_close"].diff()
+        df["r"] = df["r"].replace([np.inf, -np.inf], np.nan)
+        df = df.dropna(subset=["r"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        def per_symbol(s: pd.Series) -> float:
+            r = s.values
+            return float(np.sum((r[r > 0]) ** 2)) if len(r) > 0 else np.nan
+
+        value = df.groupby("symbol")["r"].apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = PosSemivarRetFeature()
+

--- a/cube2mat/features/ret_skew.py
+++ b/cube2mat/features/ret_skew.py
@@ -1,0 +1,72 @@
+# features/ret_skew.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class RetSkewFeature(BaseFeature):
+    """
+    09:30–15:59 内，log 收益的样本修正偏度：
+      g1 = [n/((n-1)(n-2))] * sum((r-mean)^3) / s^3，s=样本标准差(ddof=1)。
+    """
+
+    name = "ret_skew"
+    description = "Sample-adjusted skewness of intraday log returns."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    @staticmethod
+    def _skew(s: pd.Series) -> float:
+        r = s.values.astype(float)
+        n = len(r)
+        if n < 3:
+            return np.nan
+        m = r.mean()
+        d = r - m
+        s2 = np.sum(d * d) / (n - 1)
+        if s2 <= 0:
+            return np.nan
+        s1 = np.sqrt(s2)
+        m3 = np.sum(d ** 3) / n
+        g1 = (n / ((n - 1) * (n - 2))) * (m3 / (s1 ** 3))
+        return float(g1)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df[(df["close"] > 0)].dropna(subset=["close"]).sort_index()
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["log_close"] = np.log(df["close"])
+        df["r"] = df.groupby("symbol", sort=False)["log_close"].diff()
+        df["r"] = df["r"].replace([np.inf, -np.inf], np.nan)
+        df = df.dropna(subset=["r"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        value = df.groupby("symbol")["r"].apply(self._skew)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = RetSkewFeature()
+

--- a/cube2mat/features/robust_vol_mad_ret.py
+++ b/cube2mat/features/robust_vol_mad_ret.py
@@ -1,0 +1,64 @@
+# features/robust_vol_mad_ret.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class RobustVolMADRetFeature(BaseFeature):
+    """
+    09:30–15:59 内，基于 log 收益的稳健波动率：
+      sigma ≈ 1.4826 * median(|r - median(r)|)；close>0。
+    """
+
+    name = "robust_vol_mad_ret"
+    description = "Robust volatility via MAD on log returns."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df[(df["close"] > 0)].dropna(subset=["close"]).sort_index()
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["log_close"] = np.log(df["close"])
+        df["r"] = df.groupby("symbol", sort=False)["log_close"].diff()
+        df["r"] = df["r"].replace([np.inf, -np.inf], np.nan)
+        df = df.dropna(subset=["r"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        def per_symbol(s: pd.Series) -> float:
+            r = s.values
+            if len(r) < 2:
+                return np.nan
+            med = np.median(r)
+            mad = np.median(np.abs(r - med))
+            return float(1.4826 * mad) if np.isfinite(mad) else np.nan
+
+        value = df.groupby("symbol")["r"].apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = RobustVolMADRetFeature()
+

--- a/cube2mat/features/rq_logret.py
+++ b/cube2mat/features/rq_logret.py
@@ -1,0 +1,62 @@
+# features/rq_logret.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class RQLogRetFeature(BaseFeature):
+    """
+    09:30–15:59 内，RQ = (N/3) * sum(r_t^4)，r_t = diff(log(close))，close>0；N=有效 r_t 数。
+    用于估计波动的方差（“vol of vol”尺度）。
+    """
+
+    name = "rq_logret"
+    description = "Realized quarticity (N/3)*sum(r^4) using log returns."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df[(df["close"] > 0)].dropna(subset=["close"]).sort_index()
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["log_close"] = np.log(df["close"])
+        df["r"] = df.groupby("symbol", sort=False)["log_close"].diff()
+        df["r"] = df["r"].replace([np.inf, -np.inf], np.nan)
+        df = df.dropna(subset=["r"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        def per_symbol(s: pd.Series) -> float:
+            n = len(s)
+            if n < 2:
+                return np.nan
+            return float((n / 3.0) * ((s ** 4).sum()))
+
+        value = df.groupby("symbol")["r"].apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = RQLogRetFeature()
+

--- a/cube2mat/features/rv_logret.py
+++ b/cube2mat/features/rv_logret.py
@@ -1,0 +1,58 @@
+# features/rv_logret.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class RVLogRetFeature(BaseFeature):
+    """
+    09:30–15:59 内，RV = sum( r_t^2 )，r_t = diff(log(close))，仅使用 close>0。
+    若有效 r_t<1 则 NaN。
+    """
+
+    name = "rv_logret"
+    description = "Realized variance using log returns: sum(diff(log(close))^2)."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df[(df["close"] > 0)].dropna(subset=["close"]).sort_index()
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["log_close"] = np.log(df["close"])
+        df["r"] = df.groupby("symbol", sort=False)["log_close"].diff()
+        df["r"] = df["r"].replace([np.inf, -np.inf], np.nan)
+        df = df.dropna(subset=["r"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        value = df.groupby("symbol")["r"].apply(
+            lambda s: float((s * s).sum()) if len(s) >= 1 else np.nan
+        )
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = RVLogRetFeature()
+

--- a/cube2mat/features/rv_per_min_logret.py
+++ b/cube2mat/features/rv_per_min_logret.py
@@ -1,0 +1,59 @@
+# features/rv_per_min_logret.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class RVPerMinLogRetFeature(BaseFeature):
+    """
+    09:30–15:59 内，RV 每分钟强度： sum(diff(log(close))^2) / TOTAL_MIN；close>0。
+    """
+
+    name = "rv_per_min_logret"
+    description = "RV per-minute intensity: RV divided by session total minutes (389)."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+    TOTAL_MIN = (
+        pd.Timedelta("15:59:00") - pd.Timedelta("09:30:00")
+    ).total_seconds() / 60.0
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df[(df["close"] > 0)].dropna(subset=["close"]).sort_index()
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["log_close"] = np.log(df["close"])
+        df["r"] = df.groupby("symbol", sort=False)["log_close"].diff()
+        df["r"] = df["r"].replace([np.inf, -np.inf], np.nan)
+        df = df.dropna(subset=["r"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        rv = df.groupby("symbol")["r"].apply(lambda s: (s * s).sum())
+        value = rv.apply(lambda x: float(x / self.TOTAL_MIN) if pd.notna(x) else np.nan)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = RVPerMinLogRetFeature()
+

--- a/cube2mat/features/rvol_logret.py
+++ b/cube2mat/features/rvol_logret.py
@@ -1,0 +1,58 @@
+# features/rvol_logret.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class RVolLogRetFeature(BaseFeature):
+    """
+    09:30–15:59 内，已实现波动率 = sqrt( sum( diff(log(close))^2 ) )；close>0。
+    """
+
+    name = "rvol_logret"
+    description = "Realized volatility: sqrt of RV using log returns."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        from math import sqrt
+
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df[(df["close"] > 0)].dropna(subset=["close"]).sort_index()
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["log_close"] = np.log(df["close"])
+        df["r"] = df.groupby("symbol", sort=False)["log_close"].diff()
+        df["r"] = df["r"].replace([np.inf, -np.inf], np.nan)
+        df = df.dropna(subset=["r"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        rv = df.groupby("symbol")["r"].apply(lambda s: (s * s).sum())
+        value = rv.apply(lambda x: float(sqrt(x)) if pd.notna(x) and x >= 0 else np.nan)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = RVolLogRetFeature()
+

--- a/cube2mat/features/semivar_pos_over_neg.py
+++ b/cube2mat/features/semivar_pos_over_neg.py
@@ -1,0 +1,61 @@
+# features/semivar_pos_over_neg.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class SemivarPosOverNegFeature(BaseFeature):
+    """
+    09:30–15:59 内，上/下行半方差比率；若下行半方差<=0 则 NaN。
+    """
+
+    name = "semivar_pos_over_neg"
+    description = "Ratio of positive to negative semivariance of log returns."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df[(df["close"] > 0)].dropna(subset=["close"]).sort_index()
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["log_close"] = np.log(df["close"])
+        df["r"] = df.groupby("symbol", sort=False)["log_close"].diff()
+        df["r"] = df["r"].replace([np.inf, -np.inf], np.nan)
+        df = df.dropna(subset=["r"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        def per_symbol(s: pd.Series) -> float:
+            r = s.values
+            pos = float(np.sum((r[r > 0]) ** 2))
+            neg = float(np.sum((r[r < 0]) ** 2))
+            return pos / neg if np.isfinite(pos) and np.isfinite(neg) and neg > 0 else np.nan
+
+        value = df.groupby("symbol")["r"].apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = SemivarPosOverNegFeature()
+

--- a/cube2mat/features/std_close_vwap_diff.py
+++ b/cube2mat/features/std_close_vwap_diff.py
@@ -1,0 +1,51 @@
+# features/std_close_vwap_diff.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class StdCloseVWAPDiffFeature(BaseFeature):
+    """
+    09:30–15:59 内，（close - vwap）的样本标准差（ddof=1）。
+    若有效样本<2 或任一列缺失，则 NaN。
+    """
+
+    name = "std_close_vwap_diff"
+    description = "Sample std of (close - vwap) within 09:30–15:59."
+    required_full_columns = ("symbol", "time", "close", "vwap")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        for c in ("close", "vwap"):
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+        df = df.dropna(subset=["close", "vwap"]).sort_index()
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["diff"] = df["close"] - df["vwap"]
+        stats = df.groupby("symbol")["diff"].agg(n="count", std=lambda s: s.std(ddof=1))
+        value = stats["std"].where(stats["n"] >= 2)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = StdCloseVWAPDiffFeature()
+

--- a/cube2mat/features/time_to_20pct_volume_frac.py
+++ b/cube2mat/features/time_to_20pct_volume_frac.py
@@ -1,0 +1,69 @@
+# features/time_to_20pct_volume_frac.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class TimeTo20PctVolumeFracFeature(BaseFeature):
+    """
+    09:30–15:59 内，累积成交量达到 20% 所需的“时间占比”（分钟/总分钟，∈[0,1]）。
+    若 sum(volume)<=0 则 NaN。
+    """
+
+    name = "time_to_20pct_volume_frac"
+    description = "Fraction of session minutes to reach 20% cumulative volume."
+    required_full_columns = ("symbol", "time", "volume")
+    required_pv_columns = ("symbol",)
+    TOTAL_MIN = (
+        pd.Timedelta("15:59:00") - pd.Timedelta("09:30:00")
+    ).total_seconds() / 60.0
+
+    @staticmethod
+    def _minutes_since_open(idx: pd.DatetimeIndex) -> np.ndarray:
+        return (
+            (idx - idx.normalize() - pd.Timedelta("09:30:00")).total_seconds() / 60.0
+        ).astype(float)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["volume"] = pd.to_numeric(df["volume"], errors="coerce")
+        df = df.dropna(subset=["volume"]).sort_index()
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        def per_symbol(g: pd.DataFrame) -> float:
+            v = g["volume"].astype(float).values
+            tot = v.sum()
+            if not np.isfinite(tot) or tot <= 0 or len(v) == 0:
+                return np.nan
+            c = np.cumsum(v)
+            thr = 0.2 * tot
+            i = int(np.searchsorted(c, thr, side="left"))
+            i = min(i, len(g) - 1)
+            minutes = self._minutes_since_open(g.index)[i]
+            return float(minutes / self.TOTAL_MIN)
+
+        value = df.groupby("symbol").apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = TimeTo20PctVolumeFracFeature()
+

--- a/cube2mat/features/volume_peak_time_frac.py
+++ b/cube2mat/features/volume_peak_time_frac.py
@@ -1,0 +1,63 @@
+# features/volume_peak_time_frac.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class VolumePeakTimeFracFeature(BaseFeature):
+    """
+    成交量峰值出现的“时间占比”（峰值出现的分钟 / 总分钟，∈[0,1]）。
+    """
+
+    name = "volume_peak_time_frac"
+    description = "Fraction of session minutes when the per-bar max volume occurs."
+    required_full_columns = ("symbol", "time", "volume")
+    required_pv_columns = ("symbol",)
+    TOTAL_MIN = (
+        pd.Timedelta("15:59:00") - pd.Timedelta("09:30:00")
+    ).total_seconds() / 60.0
+
+    @staticmethod
+    def _minutes_since_open(ts: pd.Timestamp) -> float:
+        return float(
+            (ts - ts.normalize() - pd.Timedelta("09:30:00")).total_seconds() / 60.0
+        )
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["volume"] = pd.to_numeric(df["volume"], errors="coerce")
+        df = df.dropna(subset=["volume"]).sort_index()
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        def per_symbol(g: pd.DataFrame) -> float:
+            idx = g["volume"].idxmax()
+            if pd.isna(idx):
+                return np.nan
+            mins = self._minutes_since_open(idx)
+            return float(mins / self.TOTAL_MIN)
+
+        value = df.groupby("symbol").apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = VolumePeakTimeFracFeature()
+


### PR DESCRIPTION
## Summary
- normalize time-based peak metrics to report fraction of session elapsed
- broaden volatility analysis with realized variance, quarticity, jump variation, semivariance and other dispersion measures
- update std_close to use ddof=1 and require only two observations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a17afa3408832a806ddf52d8494d1e