### PR TITLE
Add extended volatility features

### DIFF
--- a/cube2mat/features/ac1_ret2.py
+++ b/cube2mat/features/ac1_ret2.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class AC1Ret2Feature(BaseFeature):
+    """
+    波动聚类刻画：log 收益平方 r^2 的 lag-1 皮尔逊自相关；len<2 或方差为 0 则 NaN。
+    """
+    name = "ac1_ret2"
+    description = "Lag-1 autocorrelation of squared log returns (volatility clustering)."
+    required_full_columns = ("symbol","time","close")
+    required_pv_columns   = ("symbol",)
+
+    @staticmethod
+    def _ac1(x: pd.Series) -> float:
+        if len(x) < 2: return np.nan
+        x0 = x.iloc[:-1].astype(float); x1 = x.iloc[1:].astype(float)
+        xd0 = x0 - x0.mean(); xd1 = x1 - x1.mean()
+        s00 = (xd0*xd0).sum(); s11 = (xd1*xd1).sum()
+        if s00 <= 0 or s11 <= 0: return np.nan
+        return float((xd0*xd1).sum() / np.sqrt(s00*s11))
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full=self.load_full(ctx,date,list(self.required_full_columns))
+        sample=self.load_pv(ctx,date,list(self.required_pv_columns))
+        if full is None or sample is None: return None
+        out=sample[["symbol"]].copy()
+        if full.empty or sample.empty: out["value"]=pd.NA; return out
+
+        df=self.ensure_et_index(full,"time",ctx.tz).between_time("09:30","15:59")
+        df=df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty: out["value"]=pd.NA; return out
+
+        df["close"]=pd.to_numeric(df["close"], errors="coerce")
+        df=df[(df["close"]>0)].dropna(subset=["close"]).sort_index()
+        if df.empty: out["value"]=pd.NA; return out
+
+        df["log_close"]=np.log(df["close"])
+        df["r"]=df.groupby("symbol",sort=False)["log_close"].diff().replace([np.inf,-np.inf],np.nan)
+        df=df.dropna(subset=["r"])
+        if df.empty: out["value"]=pd.NA; return out
+
+        df["r2"]=df["r"]*df["r"]
+        value=df.groupby("symbol")["r2"].apply(self._ac1)
+        out["value"]=out["symbol"].map(value)
+        return out
+
+feature = AC1Ret2Feature()

--- a/cube2mat/features/corr_absret_n.py
+++ b/cube2mat/features/corr_absret_n.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class CorrAbsRetNFeature(BaseFeature):
+    """
+    |log 收益| 与成交笔数 n 的皮尔逊相关：corr(|r|, n)。
+    """
+    name = "corr_absret_n"
+    description = "Pearson correlation between |log returns| and trade count n."
+    required_full_columns = ("symbol","time","close","n")
+    required_pv_columns   = ("symbol",)
+
+    @staticmethod
+    def _pearson_corr(x: pd.Series, y: pd.Series) -> float:
+        n = len(x)
+        if n < 2: return np.nan
+        xd = x - x.mean(); yd = y - y.mean()
+        sxx = (xd*xd).sum(); syy = (yd*yd).sum()
+        if sxx <= 0 or syy <= 0: return np.nan
+        return float((xd*yd).sum()/np.sqrt(sxx*syy))
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full=self.load_full(ctx,date,list(self.required_full_columns))
+        sample=self.load_pv(ctx,date,list(self.required_pv_columns))
+        if full is None or sample is None: return None
+
+        out=sample[["symbol"]].copy()
+        if full.empty or sample.empty: out["value"]=pd.NA; return out
+
+        df=self.ensure_et_index(full,"time",ctx.tz).between_time("09:30","15:59")
+        df=df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty: out["value"]=pd.NA; return out
+
+        for c in ("close","n"):
+            df[c]=pd.to_numeric(df[c], errors="coerce")
+        df=df[(df["close"]>0)].dropna(subset=["close","n"]).sort_index()
+        if df.empty: out["value"]=pd.NA; return out
+
+        df["log_close"]=np.log(df["close"])
+        df["r"]=df.groupby("symbol",sort=False)["log_close"].diff().replace([np.inf,-np.inf],np.nan)
+        df=df.dropna(subset=["r"])
+        if df.empty: out["value"]=pd.NA; return out
+
+        df["absr"]=df["r"].abs()
+        value = df.groupby("symbol").apply(lambda g: self._pearson_corr(g["absr"], g["n"]))
+        out["value"]=out["symbol"].map(value)
+        return out
+
+feature = CorrAbsRetNFeature()

--- a/cube2mat/features/corr_absret_volume.py
+++ b/cube2mat/features/corr_absret_volume.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class CorrAbsRetVolumeFeature(BaseFeature):
+    """
+    |log 收益| 与成交量的皮尔逊相关：corr(|r|, volume)。
+    对齐为“收益时刻”的体量（即差分后的后一个 bar 的 volume）。
+    样本<2 或方差为 0 则 NaN。
+    """
+    name = "corr_absret_volume"
+    description = "Pearson correlation between |log returns| and volume within session."
+    required_full_columns = ("symbol","time","close","volume")
+    required_pv_columns   = ("symbol",)
+
+    @staticmethod
+    def _pearson_corr(x: pd.Series, y: pd.Series) -> float:
+        n = len(x)
+        if n < 2: return np.nan
+        xd = x - x.mean(); yd = y - y.mean()
+        sxx = (xd*xd).sum(); syy = (yd*yd).sum()
+        if sxx <= 0 or syy <= 0: return np.nan
+        return float((xd*yd).sum()/np.sqrt(sxx*syy))
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full=self.load_full(ctx,date,list(self.required_full_columns))
+        sample=self.load_pv(ctx,date,list(self.required_pv_columns))
+        if full is None or sample is None: return None
+        out=sample[["symbol"]].copy()
+        if full.empty or sample.empty: out["value"]=pd.NA; return out
+
+        df=self.ensure_et_index(full,"time",ctx.tz).between_time("09:30","15:59")
+        df=df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty: out["value"]=pd.NA; return out
+
+        for c in ("close","volume"):
+            df[c]=pd.to_numeric(df[c], errors="coerce")
+        df=df[(df["close"]>0)].dropna(subset=["close","volume"]).sort_index()
+        if df.empty: out["value"]=pd.NA; return out
+
+        df["log_close"]=np.log(df["close"])
+        df["r"]=df.groupby("symbol",sort=False)["log_close"].diff().replace([np.inf,-np.inf],np.nan)
+        df=df.dropna(subset=["r"])
+        if df.empty: out["value"]=pd.NA; return out
+
+        df["absr"]=df["r"].abs()
+        # 对齐 volume（收益时刻为“后一个 bar”时间戳）
+        df = df.dropna(subset=["absr","volume"])
+        value = df.groupby("symbol").apply(lambda g: self._pearson_corr(g["absr"], g["volume"]))
+        out["value"]=out["symbol"].map(value)
+        return out
+
+feature = CorrAbsRetVolumeFeature()

--- a/cube2mat/features/corr_ret2_volume.py
+++ b/cube2mat/features/corr_ret2_volume.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class CorrRet2VolumeFeature(BaseFeature):
+    """
+    r^2 与 volume 的皮尔逊相关：corr(r_t^2, volume_t)，衡量量与瞬时方差的联动。
+    """
+    name = "corr_ret2_volume"
+    description = "Pearson correlation between squared log returns and volume."
+    required_full_columns = ("symbol","time","close","volume")
+    required_pv_columns   = ("symbol",)
+
+    @staticmethod
+    def _pearson_corr(x: pd.Series, y: pd.Series) -> float:
+        if len(x) < 2: return np.nan
+        xd = x - x.mean(); yd = y - y.mean()
+        sxx = (xd*xd).sum(); syy = (yd*yd).sum()
+        if sxx <= 0 or syy <= 0: return np.nan
+        return float((xd*yd).sum()/np.sqrt(sxx*syy))
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full=self.load_full(ctx,date,list(self.required_full_columns))
+        sample=self.load_pv(ctx,date,list(self.required_pv_columns))
+        if full is None or sample is None: return None
+
+        out=sample[["symbol"]].copy()
+        if full.empty or sample.empty: out["value"]=pd.NA; return out
+
+        df=self.ensure_et_index(full,"time",ctx.tz).between_time("09:30","15:59")
+        df=df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty: out["value"]=pd.NA; return out
+
+        for c in ("close","volume"):
+            df[c]=pd.to_numeric(df[c], errors="coerce")
+        df=df[(df["close"]>0)].dropna(subset=["close","volume"]).sort_index()
+        if df.empty: out["value"]=pd.NA; return out
+
+        df["log_close"]=np.log(df["close"])
+        df["r"]=df.groupby("symbol",sort=False)["log_close"].diff().replace([np.inf,-np.inf],np.nan)
+        df=df.dropna(subset=["r"])
+        if df.empty: out["value"]=pd.NA; return out
+
+        df["r2"]=df["r"]*df["r"]
+        value = df.groupby("symbol").apply(lambda g: self._pearson_corr(g["r2"], g["volume"]))
+        out["value"]=out["symbol"].map(value)
+        return out
+
+feature = CorrRet2VolumeFeature()

--- a/cube2mat/features/garman_klass_session_vol.py
+++ b/cube2mat/features/garman_klass_session_vol.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class GarmanKlassSessionVolFeature(BaseFeature):
+    """
+    会话级 Garman–Klass 波动率（基于本日会话的 O/H/L/C 聚合）：
+      O = 会话首笔 open、C = 会话末笔 close、H = 会话内 max(high)、L = 会话内 min(low)
+      var_GK = 0.5*[ln(H/L)]^2 - (2ln2 - 1)*[ln(C/O)]^2
+      vol    = sqrt(max(var_GK, 0))
+    要求 O,H,L,C > 0，否则 NaN。
+    """
+    name = "garman_klass_session_vol"
+    description = "Session-level Garman–Klass volatility using aggregated O/H/L/C."
+    required_full_columns = ("symbol", "time", "open", "high", "low", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx,date,list(self.required_full_columns))
+        sample = self.load_pv(ctx,date,list(self.required_pv_columns))
+        if full is None or sample is None: return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty: out["value"]=pd.NA; return out
+
+        df  = self.ensure_et_index(full,"time",ctx.tz).between_time("09:30","15:59")
+        df  = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty: out["value"]=pd.NA; return out
+
+        for c in ("open","high","low","close"):
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+        df = df.dropna(subset=["open","high","low","close"])
+        if df.empty: out["value"]=pd.NA; return out
+        df = df.sort_index()
+
+        def per_symbol(g: pd.DataFrame) -> float:
+            O = g["open"].dropna().iloc[0]
+            C = g["close"].dropna().iloc[-1]
+            H = g["high"].max()
+            L = g["low"].min()
+            if not all(np.isfinite(x) and x>0 for x in (O,H,L,C)): return np.nan
+            lnHL = np.log(H/L)
+            lnCO = np.log(C/O)
+            var_gk = 0.5*(lnHL*lnHL) - (2.0*np.log(2.0)-1.0)*(lnCO*lnCO)
+            if not np.isfinite(var_gk): return np.nan
+            var_gk = max(var_gk, 0.0)
+            return float(np.sqrt(var_gk))
+
+        value = df.groupby("symbol").apply(per_symbol)
+        out["value"]=out["symbol"].map(value)
+        return out
+
+feature = GarmanKlassSessionVolFeature()

--- a/cube2mat/features/gk_var_sum_ohlc.py
+++ b/cube2mat/features/gk_var_sum_ohlc.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class GKVarSumOHLCFeature(BaseFeature):
+    """
+    逐 bar 的 Garman–Klass 方差并在会话内求和（近似集成方差）：
+      var_i = 0.5*[ln(H_i/L_i)]^2 - (2ln2 - 1)*[ln(C_i/O_i)]^2，按 bar 计算后 clip 至 >=0 再求和。
+    要求各 bar 的 O/H/L/C > 0；若无有效 bar 或总和<=0 则 NaN。
+    """
+    name = "gk_var_sum_ohlc"
+    description = "Sum of per-bar GK variance across the session (clipped at 0)."
+    required_full_columns = ("symbol","time","open","high","low","close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full=self.load_full(ctx,date,list(self.required_full_columns))
+        sample=self.load_pv(ctx,date,list(self.required_pv_columns))
+        if full is None or sample is None: return None
+        out=sample[["symbol"]].copy()
+        if full.empty or sample.empty: out["value"]=pd.NA; return out
+
+        df=self.ensure_et_index(full,"time",ctx.tz).between_time("09:30","15:59")
+        df=df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty: out["value"]=pd.NA; return out
+
+        for c in ("open","high","low","close"):
+            df[c]=pd.to_numeric(df[c], errors="coerce")
+        df=df.dropna(subset=["open","high","low","close"])
+        if df.empty: out["value"]=pd.NA; return out
+
+        df = df[(df["open"]>0)&(df["high"]>0)&(df["low"]>0)&(df["close"]>0)].copy()
+        if df.empty: out["value"]=pd.NA; return out
+
+        lnHL = np.log(df["high"]/df["low"])
+        lnCO = np.log(df["close"]/df["open"])
+        df["gk_var"] = 0.5*(lnHL*lnHL) - (2.0*np.log(2.0)-1.0)*(lnCO*lnCO)
+        df["gk_var"] = df["gk_var"].clip(lower=0.0)
+
+        value = df.groupby("symbol")["gk_var"].sum()
+        value = value.where(value>0)
+        out["value"]=out["symbol"].map(value)
+        return out
+
+feature = GKVarSumOHLCFeature()

--- a/cube2mat/features/iqr_vol_logret.py
+++ b/cube2mat/features/iqr_vol_logret.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class IQRVolLogRetFeature(BaseFeature):
+    """
+    基于 log 收益的稳健波动率（IQR 标定）：
+      r = diff(log(close))；sigma_IQR ≈ 0.7413 * IQR(r) = 0.7413 * (Q75 - Q25)。
+    有效 r 数 < 3 则 NaN。
+    """
+    name = "iqr_vol_logret"
+    description = "Robust volatility via 0.7413*IQR of log returns."
+    required_full_columns = ("symbol","time","close")
+    required_pv_columns   = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full=self.load_full(ctx,date,list(self.required_full_columns))
+        sample=self.load_pv(ctx,date,list(self.required_pv_columns))
+        if full is None or sample is None: return None
+        out=sample[["symbol"]].copy()
+        if full.empty or sample.empty: out["value"]=pd.NA; return out
+
+        df=self.ensure_et_index(full,"time",ctx.tz).between_time("09:30","15:59")
+        df=df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty: out["value"]=pd.NA; return out
+
+        df["close"]=pd.to_numeric(df["close"], errors="coerce")
+        df=df[(df["close"]>0)].dropna(subset=["close"]).sort_index()
+        if df.empty: out["value"]=pd.NA; return out
+
+        df["log_close"]=np.log(df["close"])
+        df["r"]=df.groupby("symbol",sort=False)["log_close"].diff().replace([np.inf,-np.inf],np.nan)
+        df=df.dropna(subset=["r"])
+        if df.empty: out["value"]=pd.NA; return out
+
+        def per_symbol(s: pd.Series)->float:
+            if len(s)<3: return np.nan
+            q75 = np.quantile(s.values, 0.75)
+            q25 = np.quantile(s.values, 0.25)
+            return float(0.7413*(q75-q25))
+
+        value=df.groupby("symbol")["r"].apply(per_symbol)
+        out["value"]=out["symbol"].map(value)
+        return out
+
+feature = IQRVolLogRetFeature()

--- a/cube2mat/features/qn_vol_logret.py
+++ b/cube2mat/features/qn_vol_logret.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class QnVolLogRetFeature(BaseFeature):
+    """
+    基于 log 收益的 Qn 稳健尺度估计（Rousseeuw & Croux）：
+      Qn = c * Q1( |r_i - r_j|, i<j )，其中 c ≈ 2.2219 使其对正态分布一致。
+    有效 r 数 < 3 则 NaN。复杂度 O(n^2)，但 n≈bar 数，通常可接受。
+    """
+    name = "qn_vol_logret"
+    description = "Robust Qn scale (2.2219 * 1st quartile of pairwise |Δr|) for log returns."
+    required_full_columns = ("symbol","time","close")
+    required_pv_columns   = ("symbol",)
+    C = 2.2219
+
+    @staticmethod
+    def _qn_scale(arr: np.ndarray) -> float:
+        n = arr.size
+        if n < 3: return np.nan
+        # 两两差的绝对值（上三角）
+        diffs = []
+        for i in range(n-1):
+            di = np.abs(arr[i+1:] - arr[i])
+            if di.size:
+                diffs.append(di)
+        if not diffs:
+            return np.nan
+        diffs = np.concatenate(diffs)
+        q1 = np.quantile(diffs, 0.25)
+        if not np.isfinite(q1):
+            return np.nan
+        return float(QnVolLogRetFeature.C * q1)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full=self.load_full(ctx,date,list(self.required_full_columns))
+        sample=self.load_pv(ctx,date,list(self.required_pv_columns))
+        if full is None or sample is None: return None
+
+        out=sample[["symbol"]].copy()
+        if full.empty or sample.empty: out["value"]=pd.NA; return out
+
+        df=self.ensure_et_index(full,"time",ctx.tz).between_time("09:30","15:59")
+        df=df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty: out["value"]=pd.NA; return out
+
+        df["close"]=pd.to_numeric(df["close"], errors="coerce")
+        df=df[(df["close"]>0)].dropna(subset=["close"]).sort_index()
+        if df.empty: out["value"]=pd.NA; return out
+
+        df["log_close"]=np.log(df["close"])
+        df["r"]=df.groupby("symbol",sort=False)["log_close"].diff().replace([np.inf,-np.inf],np.nan)
+        df=df.dropna(subset=["r"])
+        if df.empty: out["value"]=pd.NA; return out
+
+        value = df.groupby("symbol")["r"].apply(lambda s: self._qn_scale(s.values.astype(float)))
+        out["value"]=out["symbol"].map(value)
+        return out
+
+feature = QnVolLogRetFeature()

--- a/cube2mat/features/ret_excess_kurtosis.py
+++ b/cube2mat/features/ret_excess_kurtosis.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class RetExcessKurtosisFeature(BaseFeature):
+    """
+    log 收益的样本修正超额峰度（fat tails）：
+      g2 = [n(n+1)/((n-1)(n-2)(n-3))]*m4/s^2 - [3(n-1)^2/((n-2)(n-3))]
+      其中 s^2 为样本方差(ddof=1)，m4 = (1/n) * sum((r-mean)^4)。
+    n<4 或 s^2<=0 则 NaN。
+    """
+    name = "ret_excess_kurtosis"
+    description = "Sample-adjusted excess kurtosis of intraday log returns."
+    required_full_columns = ("symbol","time","close")
+    required_pv_columns   = ("symbol",)
+
+    @staticmethod
+    def _excess_kurt(s: pd.Series) -> float:
+        r = s.values.astype(float)
+        n = len(r)
+        if n < 4: return np.nan
+        m = r.mean()
+        d = r - m
+        s2 = np.sum(d*d)/(n-1)
+        if s2 <= 0: return np.nan
+        m4 = np.sum(d**4)/n
+        g2 = (n*(n+1))/((n-1)*(n-2)*(n-3)) * (m4/(s2*s2)) - (3*(n-1)*(n-1))/((n-2)*(n-3))
+        return float(g2)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full=self.load_full(ctx,date,list(self.required_full_columns))
+        sample=self.load_pv(ctx,date,list(self.required_pv_columns))
+        if full is None or sample is None: return None
+
+        out=sample[["symbol"]].copy()
+        if full.empty or sample.empty: out["value"]=pd.NA; return out
+
+        df=self.ensure_et_index(full,"time",ctx.tz).between_time("09:30","15:59")
+        df=df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty: out["value"]=pd.NA; return out
+
+        df["close"]=pd.to_numeric(df["close"], errors="coerce")
+        df=df[(df["close"]>0)].dropna(subset=["close"]).sort_index()
+        if df.empty: out["value"]=pd.NA; return out
+
+        df["log_close"]=np.log(df["close"])
+        df["r"]=df.groupby("symbol",sort=False)["log_close"].diff().replace([np.inf,-np.inf],np.nan)
+        df=df.dropna(subset=["r"])
+        if df.empty: out["value"]=pd.NA; return out
+
+        value=df.groupby("symbol")["r"].apply(self._excess_kurt)
+        out["value"]=out["symbol"].map(value)
+        return out
+
+feature = RetExcessKurtosisFeature()

--- a/cube2mat/features/rogers_satchell_session_vol.py
+++ b/cube2mat/features/rogers_satchell_session_vol.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class RogersSatchellSessionVolFeature(BaseFeature):
+    """
+    会话级 Rogers–Satchell 波动率（基于 O/H/L/C 聚合）：
+      var_RS = ln(H/C)*ln(H/O) + ln(L/C)*ln(L/O)
+      vol    = sqrt(max(var_RS, 0))
+    要求 O,H,L,C > 0，否则 NaN。
+    """
+    name = "rogers_satchell_session_vol"
+    description = "Session-level Rogers–Satchell volatility using aggregated O/H/L/C."
+    required_full_columns = ("symbol", "time", "open", "high", "low", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx,date,list(self.required_full_columns))
+        sample = self.load_pv(ctx,date,list(self.required_pv_columns))
+        if full is None or sample is None: return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty: out["value"]=pd.NA; return out
+
+        df  = self.ensure_et_index(full,"time",ctx.tz).between_time("09:30","15:59")
+        df  = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty: out["value"]=pd.NA; return out
+
+        for c in ("open","high","low","close"):
+            df[c]=pd.to_numeric(df[c], errors="coerce")
+        df=df.dropna(subset=["open","high","low","close"])
+        if df.empty: out["value"]=pd.NA; return out
+        df=df.sort_index()
+
+        def per_symbol(g: pd.DataFrame) -> float:
+            O = g["open"].dropna().iloc[0]
+            C = g["close"].dropna().iloc[-1]
+            H = g["high"].max()
+            L = g["low"].min()
+            if not all(np.isfinite(x) and x>0 for x in (O,H,L,C)): return np.nan
+            v = np.log(H/C)*np.log(H/O) + np.log(L/C)*np.log(L/O)
+            if not np.isfinite(v): return np.nan
+            v = max(v, 0.0)
+            return float(np.sqrt(v))
+
+        value = df.groupby("symbol").apply(per_symbol)
+        out["value"]=out["symbol"].map(value)
+        return out
+
+feature = RogersSatchellSessionVolFeature()

--- a/cube2mat/features/rv_close_vwap_diff.py
+++ b/cube2mat/features/rv_close_vwap_diff.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class RVDiffCloseVWAPFeature(BaseFeature):
+    """
+    相对 VWAP 溢价（close - vwap）的已实现“变差”（一阶差分的平方和）：
+      x_t = close_t - vwap_t；RV_diff = sum( (x_t - x_{t-1})^2 )。
+    需成对有效 close/vwap；有效差分<1 则 NaN。
+    """
+    name = "rv_close_vwap_diff"
+    description = "Realized variance of (close - vwap): sum of squared first differences."
+    required_full_columns = ("symbol","time","close","vwap")
+    required_pv_columns   = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full=self.load_full(ctx,date,list(self.required_full_columns))
+        sample=self.load_pv(ctx,date,list(self.required_pv_columns))
+        if full is None or sample is None: return None
+
+        out=sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"]=pd.NA; return out
+
+        df=self.ensure_et_index(full,"time",ctx.tz).between_time("09:30","15:59").sort_index()
+        df=df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"]=pd.NA; return out
+
+        for c in ("close","vwap"):
+            df[c]=pd.to_numeric(df[c], errors="coerce")
+        df=df.dropna(subset=["close","vwap"])
+        if df.empty:
+            out["value"]=pd.NA; return out
+
+        df["x"]=df["close"] - df["vwap"]
+        df["dx"]=df.groupby("symbol", sort=False)["x"].diff()
+        df["dx"]=df["dx"].replace([np.inf,-np.inf], np.nan)
+        df=df.dropna(subset=["dx"])
+        if df.empty:
+            out["value"]=pd.NA; return out
+
+        value = df.groupby("symbol")["dx"].apply(lambda s: float((s*s).sum()) if len(s)>=1 else np.nan)
+        out["value"]=out["symbol"].map(value)
+        return out
+
+feature = RVDiffCloseVWAPFeature()

--- a/cube2mat/features/rv_gini_concentration.py
+++ b/cube2mat/features/rv_gini_concentration.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class RVGiniConcentrationFeature(BaseFeature):
+    """
+    RV 的 Gini 集中度（r^2 的不均衡程度）：
+      对 y_i = r_i^2（i=1..n），按升序排序：
+      G = [sum_{i=1}^n (2i - n - 1) * y_i] / [n * sum y_i]，取值 ∈ [0,1)；越大越集中。
+    若 sum y_i <= 0 或 n<2 则 NaN。
+    """
+    name = "rv_gini_concentration"
+    description = "Gini concentration of realized variance contributions r^2."
+    required_full_columns = ("symbol","time","close")
+    required_pv_columns   = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full=self.load_full(ctx,date,list(self.required_full_columns))
+        sample=self.load_pv(ctx,date,list(self.required_pv_columns))
+        if full is None or sample is None: return None
+
+        out=sample[["symbol"]].copy()
+        if full.empty or sample.empty: out["value"]=pd.NA; return out
+
+        df=self.ensure_et_index(full,"time",ctx.tz).between_time("09:30","15:59")
+        df=df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty: out["value"]=pd.NA; return out
+
+        df["close"]=pd.to_numeric(df["close"], errors="coerce")
+        df=df[(df["close"]>0)].dropna(subset=["close"]).sort_index()
+        if df.empty: out["value"]=pd.NA; return out
+
+        df["log_close"]=np.log(df["close"])
+        df["r"]=df.groupby("symbol",sort=False)["log_close"].diff().replace([np.inf,-np.inf],np.nan)
+        df=df.dropna(subset=["r"])
+        if df.empty: out["value"]=pd.NA; return out
+
+        def per_symbol(s: pd.Series) -> float:
+            y = (s.values**2).astype(float)
+            n = y.size
+            if n < 2: return np.nan
+            tot = y.sum()
+            if not np.isfinite(tot) or tot <= 0: return np.nan
+            y.sort()
+            i = np.arange(1, n+1, dtype=float)
+            G = np.sum((2*i - n - 1) * y) / (n * tot)
+            return float(G)
+
+        value = df.groupby("symbol")["r"].apply(per_symbol)
+        out["value"]=out["symbol"].map(value)
+        return out
+
+feature = RVGiniConcentrationFeature()

--- a/cube2mat/features/rv_last30m_share.py
+++ b/cube2mat/features/rv_last30m_share.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class RVLast30mShareFeature(BaseFeature):
+    """
+    末 30 分钟已实现方差占比：
+      share = sum_{t in last30m}(r_t^2) / sum_{all}(r_t^2)
+    r_t = diff(log(close))；close>0。若分母<=0 则 NaN。
+    """
+    name = "rv_last30m_share"
+    description = "Share of realized variance contributed by the last 30 minutes of the session."
+    required_full_columns = ("symbol","time","close")
+    required_pv_columns   = ("symbol",)
+    TOTAL_MIN = (pd.Timedelta("15:59:00") - pd.Timedelta("09:30:00")).total_seconds()/60.0
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full=self.load_full(ctx,date,list(self.required_full_columns))
+        sample=self.load_pv(ctx,date,list(self.required_pv_columns))
+        if full is None or sample is None: return None
+
+        out=sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"]=pd.NA; return out
+
+        df=self.ensure_et_index(full,"time",ctx.tz).between_time("09:30","15:59").sort_index()
+        df=df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"]=pd.NA; return out
+
+        df["close"]=pd.to_numeric(df["close"], errors="coerce")
+        df=df[(df["close"]>0)].dropna(subset=["close"])
+        if df.empty: out["value"]=pd.NA; return out
+
+        df["log_close"]=np.log(df["close"])
+        df["r"]=df.groupby("symbol",sort=False)["log_close"].diff().replace([np.inf,-np.inf],np.nan)
+        df=df.dropna(subset=["r"])
+        if df.empty:
+            out["value"]=pd.NA; return out
+
+        tmin = (df.index - df.index.normalize() - pd.Timedelta("09:30:00")).total_seconds()/60.0
+        df["t_min"] = tmin
+
+        def per_symbol(g: pd.DataFrame) -> float:
+            r2 = (g["r"]*g["r"])
+            denom = float(r2.sum())
+            if denom <= 0: return np.nan
+            last = r2[g["t_min"] >= (self.TOTAL_MIN - 30.0)].sum()
+            return float(last/denom)
+
+        value = df.groupby("symbol").apply(per_symbol)
+        out["value"]=out["symbol"].map(value)
+        return out
+
+feature = RVLast30mShareFeature()

--- a/cube2mat/features/var_conc_top_decile.py
+++ b/cube2mat/features/var_conc_top_decile.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class VarConcTopDecileFeature(BaseFeature):
+    """
+    方差贡献集中度（Top 10%）：RV_top10 / RV_total，其中
+      RV_total = sum(r^2)，r=diff(log(close))；
+      RV_top10 = 对 r^2 的 90% 分位数阈值以上部分的总和。
+    分母<=0 或有效 r<2 则 NaN。
+    """
+    name = "var_conc_top_decile"
+    description = "Share of realized variance contributed by the top 10% largest r^2."
+    required_full_columns = ("symbol","time","close")
+    required_pv_columns   = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full=self.load_full(ctx,date,list(self.required_full_columns))
+        sample=self.load_pv(ctx,date,list(self.required_pv_columns))
+        if full is None or sample is None: return None
+        out=sample[["symbol"]].copy()
+        if full.empty or sample.empty: out["value"]=pd.NA; return out
+
+        df=self.ensure_et_index(full,"time",ctx.tz).between_time("09:30","15:59")
+        df=df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty: out["value"]=pd.NA; return out
+
+        df["close"]=pd.to_numeric(df["close"], errors="coerce")
+        df=df[(df["close"]>0)].dropna(subset=["close"]).sort_index()
+        if df.empty: out["value"]=pd.NA; return out
+
+        df["log_close"]=np.log(df["close"])
+        df["r"]=df.groupby("symbol",sort=False)["log_close"].diff().replace([np.inf,-np.inf],np.nan)
+        df=df.dropna(subset=["r"])
+        if df.empty: out["value"]=pd.NA; return out
+
+        def per_symbol(g: pd.DataFrame) -> float:
+            r2 = (g["r"]*g["r"]).values
+            if r2.size < 2: return np.nan
+            total = float(r2.sum())
+            if total <= 0: return np.nan
+            thr = np.quantile(r2, 0.9)
+            top = float(r2[r2 >= thr].sum())
+            return top/total
+
+        value = df.groupby("symbol").apply(per_symbol)
+        out["value"]=out["symbol"].map(value)
+        return out
+
+feature = VarConcTopDecileFeature()


### PR DESCRIPTION
## Summary
- add session-level volatility measures (Garman–Klass and Rogers–Satchell)
- implement per-bar GK variance sum and robust volatility estimators (IQR, Qn)
- introduce variance concentration, volume-return correlations, and other intraday volatility metrics

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a17c2cb58c832a9f8c36a6096b316c