### PR TITLE
Add conditional intraday features

### DIFF
--- a/cube2mat/features/cond_diff_next_ret_up_minus_down.py
+++ b/cube2mat/features/cond_diff_next_ret_up_minus_down.py
@@ -1,0 +1,55 @@
+# features/cond_diff_next_ret_up_minus_down.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class CondDiffNextRetUpMinusDownFeature(BaseFeature):
+    """
+    条件差：E[ret_{t+1}|ret_t>0] - E[ret_{t+1}|ret_t<0]。
+    两侧触发样本均需≥3，否则 NaN。
+    """
+
+    name = "cond_diff_next_ret_up_minus_down"
+    description = "Difference between next-return means after up vs down bars."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, ["symbol", "time", "close"])
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59").sort_index()
+        if df.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["ret"] = df.groupby("symbol", sort=False)["close"].pct_change().replace([np.inf, -np.inf], np.nan)
+        df["ret_next"] = df.groupby("symbol", sort=False)["ret"].shift(-1)
+        df = df.dropna(subset=["ret", "ret_next"])
+
+        def per_symbol(g: pd.DataFrame) -> float:
+            up = g.loc[g["ret"] > 0, "ret_next"]
+            dn = g.loc[g["ret"] < 0, "ret_next"]
+            if up.size < 3 or dn.size < 3:
+                return np.nan
+            return float(up.mean() - dn.mean())
+
+        value = df.groupby("symbol").apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = CondDiffNextRetUpMinusDownFeature()

--- a/cube2mat/features/down_bar_share.py
+++ b/cube2mat/features/down_bar_share.py
@@ -1,0 +1,57 @@
+# features/down_bar_share.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class DownBarShareFeature(BaseFeature):
+    """
+    09:30–15:59 内，下跌 bar 占比：count(ret<0) / count(valid ret)
+    """
+
+    name = "down_bar_share"
+    description = "Share of bars with negative simple return within the session."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59").sort_index()
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["ret"] = df.groupby("symbol", sort=False)["close"].pct_change()
+        df["ret"] = df["ret"].replace([np.inf, -np.inf], np.nan)
+        df = df.dropna(subset=["ret"])
+
+        def per_symbol(g: pd.DataFrame) -> float:
+            n = g["ret"].count()
+            if n == 0:
+                return np.nan
+            k = (g["ret"] < 0).sum()
+            return float(k / n)
+
+        value = df.groupby("symbol").apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = DownBarShareFeature()

--- a/cube2mat/features/down_mean_absret.py
+++ b/cube2mat/features/down_mean_absret.py
@@ -1,0 +1,49 @@
+# features/down_mean_absret.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class DownMeanAbsRetFeature(BaseFeature):
+    """
+    下跌状态（ret<0）下 |ret| 的均值。有效下跌样本<1 则 NaN。
+    """
+
+    name = "down_mean_absret"
+    description = "Mean absolute simple return conditional on ret<0."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, ["symbol", "time", "close"])
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59").sort_index()
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+        df["ret"] = df.groupby("symbol", sort=False)["close"].pct_change().replace([np.inf, -np.inf], np.nan)
+        df = df.dropna(subset=["ret"])
+
+        def per_symbol(g: pd.DataFrame) -> float:
+            x = g.loc[g["ret"] < 0, "ret"].abs()
+            return float(x.mean()) if x.size > 0 else np.nan
+
+        value = df.groupby("symbol").apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = DownMeanAbsRetFeature()

--- a/cube2mat/features/max_down_run_len.py
+++ b/cube2mat/features/max_down_run_len.py
@@ -1,0 +1,52 @@
+# features/max_down_run_len.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class MaxDownRunLenFeature(BaseFeature):
+    """
+    最长连跌长度（ret<0 的连续段最大长度）。
+    """
+
+    name = "max_down_run_len"
+    description = "Maximum consecutive length of negative-return run."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    @staticmethod
+    def _max_run(mask: pd.Series) -> float:
+        if mask.empty:
+            return np.nan
+        run_id = (mask != mask.shift()).cumsum()
+        lengths = mask.groupby(run_id).sum()
+        if lengths.empty:
+            return np.nan
+        return float(lengths.max()) if lengths.max() > 0 else np.nan
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, ["symbol", "time", "close"])
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59").sort_index()
+        if df.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+
+        df["ret"] = df.groupby("symbol", sort=False)["close"].pct_change().replace([np.inf, -np.inf], np.nan)
+        df = df.dropna(subset=["ret"])
+
+        value = df.groupby("symbol").apply(lambda g: self._max_run(g["ret"] < 0))
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = MaxDownRunLenFeature()

--- a/cube2mat/features/max_up_run_len.py
+++ b/cube2mat/features/max_up_run_len.py
@@ -1,0 +1,52 @@
+# features/max_up_run_len.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class MaxUpRunLenFeature(BaseFeature):
+    """
+    最长连涨长度（ret>0 的连续段最大长度）。
+    """
+
+    name = "max_up_run_len"
+    description = "Maximum consecutive length of positive-return run."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    @staticmethod
+    def _max_run(mask: pd.Series) -> float:
+        if mask.empty:
+            return np.nan
+        run_id = (mask != mask.shift()).cumsum()
+        lengths = mask.groupby(run_id).sum()
+        if lengths.empty:
+            return np.nan
+        return float(lengths.max()) if lengths.max() > 0 else np.nan
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, ["symbol", "time", "close"])
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59").sort_index()
+        if df.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+
+        df["ret"] = df.groupby("symbol", sort=False)["close"].pct_change().replace([np.inf, -np.inf], np.nan)
+        df = df.dropna(subset=["ret"])
+
+        value = df.groupby("symbol").apply(lambda g: self._max_run(g["ret"] > 0))
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = MaxUpRunLenFeature()

--- a/cube2mat/features/mean_volume_per_trade_down.py
+++ b/cube2mat/features/mean_volume_per_trade_down.py
@@ -1,0 +1,55 @@
+# features/mean_volume_per_trade_down.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class MeanVolPerTradeDownFeature(BaseFeature):
+    """
+    下跌状态的“每笔平均量”： sum(volume|ret<0)/sum(n|ret<0)。
+    """
+
+    name = "mean_volume_per_trade_down"
+    description = "Average volume per trade on down bars."
+    required_full_columns = ("symbol", "time", "close", "volume", "n")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, ["symbol", "time", "close", "volume", "n"])
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        if df.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+
+        for c in ("close", "volume", "n"):
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+        df = df.dropna(subset=["close", "volume", "n"]).sort_index()
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["ret"] = df.groupby("symbol", sort=False)["close"].pct_change().replace([np.inf, -np.inf], np.nan)
+        df = df.dropna(subset=["ret"])
+
+        def per_symbol(g: pd.DataFrame) -> float:
+            gv = g.loc[g["ret"] < 0, ["volume", "n"]]
+            v = float(gv["volume"].sum())
+            k = float(gv["n"].sum())
+            if not np.isfinite(k) or k <= 0:
+                return np.nan
+            return float(v / k)
+
+        value = df.groupby("symbol").apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = MeanVolPerTradeDownFeature()

--- a/cube2mat/features/mean_volume_per_trade_up.py
+++ b/cube2mat/features/mean_volume_per_trade_up.py
@@ -1,0 +1,56 @@
+# features/mean_volume_per_trade_up.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class MeanVolPerTradeUpFeature(BaseFeature):
+    """
+    上涨状态的“每笔平均量”： sum(volume|ret>0)/sum(n|ret>0)。
+    sum(n)<=0 则 NaN。
+    """
+
+    name = "mean_volume_per_trade_up"
+    description = "Average volume per trade on up bars."
+    required_full_columns = ("symbol", "time", "close", "volume", "n")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, ["symbol", "time", "close", "volume", "n"])
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        if df.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+
+        for c in ("close", "volume", "n"):
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+        df = df.dropna(subset=["close", "volume", "n"]).sort_index()
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["ret"] = df.groupby("symbol", sort=False)["close"].pct_change().replace([np.inf, -np.inf], np.nan)
+        df = df.dropna(subset=["ret"])
+
+        def per_symbol(g: pd.DataFrame) -> float:
+            gv = g.loc[g["ret"] > 0, ["volume", "n"]]
+            v = float(gv["volume"].sum())
+            k = float(gv["n"].sum())
+            if not np.isfinite(k) or k <= 0:
+                return np.nan
+            return float(v / k)
+
+        value = df.groupby("symbol").apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = MeanVolPerTradeUpFeature()

--- a/cube2mat/features/mvpt_up_over_down_ratio.py
+++ b/cube2mat/features/mvpt_up_over_down_ratio.py
@@ -1,0 +1,59 @@
+# features/mvpt_up_over_down_ratio.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class MVPTUpOverDownRatioFeature(BaseFeature):
+    """
+    上/下“每笔平均量”之比：
+      ratio = [sum(vol|ret>0)/sum(n|ret>0)] / [sum(vol|ret<0)/sum(n|ret<0)]
+    分母<=0 时 NaN。
+    """
+
+    name = "mvpt_up_over_down_ratio"
+    description = "Ratio of mean volume per trade on up vs down bars."
+    required_full_columns = ("symbol", "time", "close", "volume", "n")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, ["symbol", "time", "close", "volume", "n"])
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        if df.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+
+        for c in ("close", "volume", "n"):
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+        df = df.dropna(subset=["close", "volume", "n"]).sort_index()
+
+        df["ret"] = df.groupby("symbol", sort=False)["close"].pct_change().replace([np.inf, -np.inf], np.nan)
+        df = df.dropna(subset=["ret"])
+
+        def per_symbol(g: pd.DataFrame) -> float:
+            v_up = g.loc[g["ret"] > 0, "volume"].sum()
+            n_up = g.loc[g["ret"] > 0, "n"].sum()
+            v_dn = g.loc[g["ret"] < 0, "volume"].sum()
+            n_dn = g.loc[g["ret"] < 0, "n"].sum()
+            if n_up <= 0 or n_dn <= 0:
+                return np.nan
+            up = v_up / n_up
+            dn = v_dn / n_dn
+            if dn <= 0:
+                return np.nan
+            return float(up / dn)
+
+        value = df.groupby("symbol").apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = MVPTUpOverDownRatioFeature()

--- a/cube2mat/features/next_ret_cond_down.py
+++ b/cube2mat/features/next_ret_cond_down.py
@@ -1,0 +1,51 @@
+# features/next_ret_cond_down.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class NextRetCondDownFeature(BaseFeature):
+    """
+    条件期望：E[ret_{t+1} | ret_t < 0]；触发样本<3 则 NaN。
+    """
+
+    name = "next_ret_cond_down"
+    description = "Mean of next simple return conditional on current ret<0."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, ["symbol", "time", "close"])
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59").sort_index()
+        if df.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["ret"] = df.groupby("symbol", sort=False)["close"].pct_change().replace([np.inf, -np.inf], np.nan)
+        df["ret_next"] = df.groupby("symbol", sort=False)["ret"].shift(-1)
+        df = df.dropna(subset=["ret", "ret_next"])
+
+        def per_symbol(g: pd.DataFrame) -> float:
+            x = g.loc[g["ret"] < 0, "ret_next"]
+            return float(x.mean()) if x.size >= 3 else np.nan
+
+        value = df.groupby("symbol").apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = NextRetCondDownFeature()

--- a/cube2mat/features/next_ret_cond_up.py
+++ b/cube2mat/features/next_ret_cond_up.py
@@ -1,0 +1,52 @@
+# features/next_ret_cond_up.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class NextRetCondUpFeature(BaseFeature):
+    """
+    条件期望：E[ret_{t+1} | ret_t > 0]。
+    用 simple return，过滤 inf/NaN；触发样本<3 则 NaN。
+    """
+
+    name = "next_ret_cond_up"
+    description = "Mean of next simple return conditional on current ret>0."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, ["symbol", "time", "close"])
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59").sort_index()
+        if df.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["ret"] = df.groupby("symbol", sort=False)["close"].pct_change().replace([np.inf, -np.inf], np.nan)
+        df["ret_next"] = df.groupby("symbol", sort=False)["ret"].shift(-1)
+        df = df.dropna(subset=["ret", "ret_next"])
+
+        def per_symbol(g: pd.DataFrame) -> float:
+            x = g.loc[g["ret"] > 0, "ret_next"]
+            return float(x.mean()) if x.size >= 3 else np.nan
+
+        value = df.groupby("symbol").apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = NextRetCondUpFeature()

--- a/cube2mat/features/premium_close_vwap_up_minus_down.py
+++ b/cube2mat/features/premium_close_vwap_up_minus_down.py
@@ -1,0 +1,54 @@
+# features/premium_close_vwap_up_minus_down.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class PremiumCloseVWAPUpMinusDownFeature(BaseFeature):
+    """
+    (close - vwap) 在上涨/下跌状态的均值之差：
+      diff = mean(close-vwap | ret>0) - mean(close-vwap | ret<0)
+    任一侧样本为空则 NaN。
+    """
+
+    name = "premium_close_vwap_up_minus_down"
+    description = "Mean(close-vwap|up) minus mean(close-vwap|down)."
+    required_full_columns = ("symbol", "time", "close", "vwap")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, ["symbol", "time", "close", "vwap"])
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        if df.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+
+        for c in ("close", "vwap"):
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+        df = df.dropna(subset=["close", "vwap"]).sort_index()
+
+        df["ret"] = df.groupby("symbol", sort=False)["close"].pct_change().replace([np.inf, -np.inf], np.nan)
+        df["diff"] = df["close"] - df["vwap"]
+        df = df.dropna(subset=["ret", "diff"])
+
+        def per_symbol(g: pd.DataFrame) -> float:
+            up = g.loc[g["ret"] > 0, "diff"].mean()
+            dn = g.loc[g["ret"] < 0, "diff"].mean()
+            if not np.isfinite(up) or not np.isfinite(dn):
+                return np.nan
+            return float(up - dn)
+
+        value = df.groupby("symbol").apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = PremiumCloseVWAPUpMinusDownFeature()

--- a/cube2mat/features/range_up_down_ratio.py
+++ b/cube2mat/features/range_up_down_ratio.py
@@ -1,0 +1,54 @@
+# features/range_up_down_ratio.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class RangeUpDownRatioFeature(BaseFeature):
+    """
+    以 (high-low) 作为区间尺度，对应上涨/下跌状态的总和之比：
+      ratio = sum(range|ret>0) / sum(range|ret<0)
+    任一侧分母<=0 则 NaN。
+    """
+
+    name = "range_up_down_ratio"
+    description = "Sum(high-low) on up bars divided by that on down bars."
+    required_full_columns = ("symbol", "time", "high", "low", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, ["symbol", "time", "high", "low", "close"])
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        if df.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+
+        for c in ("high", "low", "close"):
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+        df = df.dropna(subset=["high", "low", "close"]).sort_index()
+        df["range"] = df["high"] - df["low"]
+
+        df["ret"] = df.groupby("symbol", sort=False)["close"].pct_change().replace([np.inf, -np.inf], np.nan)
+        df = df.dropna(subset=["ret", "range"])
+
+        def per_symbol(g: pd.DataFrame) -> float:
+            up = g.loc[g["ret"] > 0, "range"].sum()
+            dn = g.loc[g["ret"] < 0, "range"].sum()
+            if dn <= 0:
+                return np.nan
+            return float(up / dn)
+
+        value = df.groupby("symbol").apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = RangeUpDownRatioFeature()

--- a/cube2mat/features/reversal_prob_after_big_down.py
+++ b/cube2mat/features/reversal_prob_after_big_down.py
@@ -1,0 +1,54 @@
+# features/reversal_prob_after_big_down.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class ReversalProbAfterBigDownFeature(BaseFeature):
+    """
+    大幅下跌后的反转概率：
+      取当日 simple return 的 10% 分位数 q10，触发集 B={t: ret_t <= q10}；
+      统计 P(ret_{t+1}>0 | t∈B)。触发样本<3 则 NaN。
+    """
+
+    name = "reversal_prob_after_big_down"
+    description = "P(next ret > 0 | current ret in bottom 10%)."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, ["symbol", "time", "close"])
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59").sort_index()
+        if df.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+
+        df["ret"] = df.groupby("symbol", sort=False)["close"].pct_change().replace([np.inf, -np.inf], np.nan)
+        df["ret_next"] = df.groupby("symbol", sort=False)["ret"].shift(-1)
+        df = df.dropna(subset=["ret", "ret_next"])
+
+        def per_symbol(g: pd.DataFrame) -> float:
+            q10 = np.quantile(g["ret"].values, 0.1)
+            B = g["ret"] <= q10
+            k = B.sum()
+            if k < 3:
+                return np.nan
+            p = (g.loc[B, "ret_next"] > 0).mean()
+            return float(p)
+
+        value = df.groupby("symbol").apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = ReversalProbAfterBigDownFeature()

--- a/cube2mat/features/reversal_prob_after_big_up.py
+++ b/cube2mat/features/reversal_prob_after_big_up.py
@@ -1,0 +1,54 @@
+# features/reversal_prob_after_big_up.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class ReversalProbAfterBigUpFeature(BaseFeature):
+    """
+    大幅上涨后的反转概率：
+      取当日 simple return 的 90% 分位数 q90，触发集 A={t: ret_t >= q90}；
+      统计 P(ret_{t+1}<0 | t∈A)。触发样本<3 则 NaN。
+    """
+
+    name = "reversal_prob_after_big_up"
+    description = "P(next ret < 0 | current ret in top 10% by magnitude and positive)."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, ["symbol", "time", "close"])
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59").sort_index()
+        if df.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+
+        df["ret"] = df.groupby("symbol", sort=False)["close"].pct_change().replace([np.inf, -np.inf], np.nan)
+        df["ret_next"] = df.groupby("symbol", sort=False)["ret"].shift(-1)
+        df = df.dropna(subset=["ret", "ret_next"])
+
+        def per_symbol(g: pd.DataFrame) -> float:
+            q90 = np.quantile(g["ret"].values, 0.9)
+            A = g["ret"] >= q90
+            k = A.sum()
+            if k < 3:
+                return np.nan
+            p = (g.loc[A, "ret_next"] < 0).mean()
+            return float(p)
+
+        value = df.groupby("symbol").apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = ReversalProbAfterBigUpFeature()

--- a/cube2mat/features/rv_share_above_vwap.py
+++ b/cube2mat/features/rv_share_above_vwap.py
@@ -1,0 +1,61 @@
+# features/rv_share_above_vwap.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class RVShareAboveVWAPFeature(BaseFeature):
+    """
+    以 log 收益 r=diff(log(close)) 计算 RV：
+      share = sum(r^2 於 (close>vwap)) / sum(r^2 全部)
+    要求 close>0。
+    """
+
+    name = "rv_share_above_vwap"
+    description = "Share of realized variance (log ret) contributed while close>vwap."
+    required_full_columns = ("symbol", "time", "close", "vwap")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, ["symbol", "time", "close", "vwap"])
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59").sort_index()
+        if df.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+
+        for c in ("close", "vwap"):
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+        df = df[(df["close"] > 0)].dropna(subset=["close", "vwap"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["logc"] = np.log(df["close"])
+        df["r"] = df.groupby("symbol", sort=False)["logc"].diff().replace([np.inf, -np.inf], np.nan)
+        df = df.dropna(subset=["r"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        def per_symbol(g: pd.DataFrame) -> float:
+            r2 = g["r"] * g["r"]
+            denom = float(r2.sum())
+            if denom <= 0:
+                return np.nan
+            share = float(r2[g["close"] > g["vwap"]].sum()) / denom
+            return share
+
+        value = df.groupby("symbol").apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = RVShareAboveVWAPFeature()

--- a/cube2mat/features/sign_change_rate.py
+++ b/cube2mat/features/sign_change_rate.py
@@ -1,0 +1,52 @@
+# features/sign_change_rate.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class SignChangeRateFeature(BaseFeature):
+    """
+    收益符号切换率：
+      rate = count(sign(ret_t) != sign(ret_{t-1}) on nonzero pairs) / count(nonzero pairs)
+    """
+
+    name = "sign_change_rate"
+    description = "Rate of sign flips between consecutive simple returns (excluding zeros)."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    @staticmethod
+    def _rate(r: pd.Series) -> float:
+        s = np.sign(r.values)
+        valid = (s[1:] != 0) & (s[:-1] != 0)
+        if valid.sum() == 0:
+            return np.nan
+        flips = (s[1:][valid] != s[:-1][valid]).sum()
+        return float(flips / valid.sum())
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, ["symbol", "time", "close"])
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59").sort_index()
+        if df.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+
+        df["ret"] = df.groupby("symbol", sort=False)["close"].pct_change().replace([np.inf, -np.inf], np.nan)
+        df = df.dropna(subset=["ret"])
+
+        value = df.groupby("symbol")["ret"].apply(self._rate)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = SignChangeRateFeature()

--- a/cube2mat/features/time_share_above_open.py
+++ b/cube2mat/features/time_share_above_open.py
@@ -1,0 +1,53 @@
+# features/time_share_above_open.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class TimeShareAboveOpenFeature(BaseFeature):
+    """
+    定义锚 = 当日首个有效 open（若缺则首个 close）。
+    时间占比 = count(close >= anchor)/count(valid close)。
+    """
+
+    name = "time_share_above_open"
+    description = "Fraction of bars with close >= session anchor (first open else first close)."
+    required_full_columns = ("symbol", "time", "open", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, ["symbol", "time", "open", "close"])
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59").sort_index()
+        if df.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+
+        for c in ("open", "close"):
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        def per_symbol(g: pd.DataFrame) -> float:
+            first_open = g["open"].dropna()
+            anchor = first_open.iloc[0] if not first_open.empty else g["close"].iloc[0]
+            if not np.isfinite(anchor):
+                return np.nan
+            x = (g["close"] >= anchor).mean()
+            return float(x)
+
+        value = df.groupby("symbol").apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = TimeShareAboveOpenFeature()

--- a/cube2mat/features/time_share_above_vwap.py
+++ b/cube2mat/features/time_share_above_vwap.py
@@ -1,0 +1,44 @@
+# features/time_share_above_vwap.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class TimeShareAboveVWAPFeature(BaseFeature):
+    """
+    收盘价高于 vwap 的时间占比： count(close>vwap)/count(valid pair)。
+    """
+
+    name = "time_share_above_vwap"
+    description = "Fraction of bars with close > vwap during the session."
+    required_full_columns = ("symbol", "time", "close", "vwap")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, ["symbol", "time", "close", "vwap"])
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        if df.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+
+        for c in ("close", "vwap"):
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+        df = df.dropna(subset=["close", "vwap"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        value = (df["close"] > df["vwap"]).groupby(df["symbol"]).mean()
+        out["value"] = out["symbol"].map(value.astype(float))
+        return out
+
+
+feature = TimeShareAboveVWAPFeature()

--- a/cube2mat/features/up_bar_share.py
+++ b/cube2mat/features/up_bar_share.py
@@ -1,0 +1,58 @@
+# features/up_bar_share.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class UpBarShareFeature(BaseFeature):
+    """
+    09:30–15:59 内，ret=close.pct_change()，上涨 bar 占比：
+      share = count(ret>0) / count(valid ret)
+    """
+
+    name = "up_bar_share"
+    description = "Share of bars with positive simple return within the session."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59").sort_index()
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["ret"] = df.groupby("symbol", sort=False)["close"].pct_change()
+        df["ret"] = df["ret"].replace([np.inf, -np.inf], np.nan)
+        df = df.dropna(subset=["ret"])
+
+        def per_symbol(g: pd.DataFrame) -> float:
+            n = g["ret"].count()
+            if n == 0:
+                return np.nan
+            k = (g["ret"] > 0).sum()
+            return float(k / n)
+
+        value = df.groupby("symbol").apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = UpBarShareFeature()

--- a/cube2mat/features/up_down_absret_ratio.py
+++ b/cube2mat/features/up_down_absret_ratio.py
@@ -1,0 +1,53 @@
+# features/up_down_absret_ratio.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class UpDownAbsRetRatioFeature(BaseFeature):
+    """
+    上/下状态 |ret| 均值之比： mean(|ret||ret>0)/mean(|ret||ret<0)。
+    分母<=0 或无有效样本时 NaN。
+    """
+
+    name = "up_down_absret_ratio"
+    description = "Ratio of mean |ret| in up vs down states."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, ["symbol", "time", "close"])
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59").sort_index()
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+        df["ret"] = df.groupby("symbol", sort=False)["close"].pct_change().replace([np.inf, -np.inf], np.nan)
+        df = df.dropna(subset=["ret"])
+
+        def per_symbol(g: pd.DataFrame) -> float:
+            up = g.loc[g["ret"] > 0, "ret"].abs().mean()
+            dn = g.loc[g["ret"] < 0, "ret"].abs().mean()
+            if not np.isfinite(up) or not np.isfinite(dn) or dn <= 0:
+                return np.nan
+            return float(up / dn)
+
+        value = df.groupby("symbol").apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = UpDownAbsRetRatioFeature()

--- a/cube2mat/features/up_mean_absret.py
+++ b/cube2mat/features/up_mean_absret.py
@@ -1,0 +1,49 @@
+# features/up_mean_absret.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class UpMeanAbsRetFeature(BaseFeature):
+    """
+    上涨状态（ret>0）下 |ret| 的均值。有效上涨样本<1 则 NaN。
+    """
+
+    name = "up_mean_absret"
+    description = "Mean absolute simple return conditional on ret>0."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, ["symbol", "time", "close"])
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59").sort_index()
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+        df["ret"] = df.groupby("symbol", sort=False)["close"].pct_change().replace([np.inf, -np.inf], np.nan)
+        df = df.dropna(subset=["ret"])
+
+        def per_symbol(g: pd.DataFrame) -> float:
+            x = g.loc[g["ret"] > 0, "ret"].abs()
+            return float(x.mean()) if x.size > 0 else np.nan
+
+        value = df.groupby("symbol").apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = UpMeanAbsRetFeature()

--- a/cube2mat/features/volume_share_on_down.py
+++ b/cube2mat/features/volume_share_on_down.py
@@ -1,0 +1,54 @@
+# features/volume_share_on_down.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class VolumeShareOnDownFeature(BaseFeature):
+    """
+    下跌状态的成交量占比： sum(volume|ret<0) / sum(volume_all)。
+    """
+
+    name = "volume_share_on_down"
+    description = "Share of total volume that occurs on down bars."
+    required_full_columns = ("symbol", "time", "close", "volume")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, ["symbol", "time", "close", "volume"])
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59").sort_index()
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+
+        for c in ("close", "volume"):
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+        df = df.dropna(subset=["close", "volume"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["ret"] = df.groupby("symbol", sort=False)["close"].pct_change().replace([np.inf, -np.inf], np.nan)
+        df = df.dropna(subset=["ret", "volume"])
+
+        def per_symbol(g: pd.DataFrame) -> float:
+            tot = g["volume"].sum()
+            if not np.isfinite(tot) or tot <= 0:
+                return np.nan
+            dnv = g.loc[g["ret"] < 0, "volume"].sum()
+            return float(dnv / tot)
+
+        value = df.groupby("symbol").apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = VolumeShareOnDownFeature()

--- a/cube2mat/features/volume_share_on_up.py
+++ b/cube2mat/features/volume_share_on_up.py
@@ -1,0 +1,55 @@
+# features/volume_share_on_up.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class VolumeShareOnUpFeature(BaseFeature):
+    """
+    上涨状态的成交量占比： sum(volume|ret>0) / sum(volume_all)。
+    若总量<=0 则 NaN。
+    """
+
+    name = "volume_share_on_up"
+    description = "Share of total volume that occurs on up bars."
+    required_full_columns = ("symbol", "time", "close", "volume")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, ["symbol", "time", "close", "volume"])
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59").sort_index()
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+
+        for c in ("close", "volume"):
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+        df = df.dropna(subset=["close", "volume"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["ret"] = df.groupby("symbol", sort=False)["close"].pct_change().replace([np.inf, -np.inf], np.nan)
+        df = df.dropna(subset=["ret", "volume"])
+
+        def per_symbol(g: pd.DataFrame) -> float:
+            tot = g["volume"].sum()
+            if not np.isfinite(tot) or tot <= 0:
+                return np.nan
+            upv = g.loc[g["ret"] > 0, "volume"].sum()
+            return float(upv / tot)
+
+        value = df.groupby("symbol").apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = VolumeShareOnUpFeature()

--- a/cube2mat/features/volume_up_down_logratio.py
+++ b/cube2mat/features/volume_up_down_logratio.py
@@ -1,0 +1,54 @@
+# features/volume_up_down_logratio.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class VolumeUpDownLogRatioFeature(BaseFeature):
+    """
+    上/下成交量的对数比： log( (sum vol|ret>0 + eps) / (sum vol|ret<0 + eps) )。
+    eps=1e-12 防零除。
+    """
+
+    name = "volume_up_down_logratio"
+    description = "Log-ratio of volumes on up vs down bars."
+    required_full_columns = ("symbol", "time", "close", "volume")
+    required_pv_columns = ("symbol",)
+    EPS = 1e-12
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, ["symbol", "time", "close", "volume"])
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59").sort_index()
+        if df.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+
+        for c in ("close", "volume"):
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+        df = df.dropna(subset=["close", "volume"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["ret"] = df.groupby("symbol", sort=False)["close"].pct_change().replace([np.inf, -np.inf], np.nan)
+        df = df.dropna(subset=["ret", "volume"])
+
+        def per_symbol(g: pd.DataFrame) -> float:
+            up = g.loc[g["ret"] > 0, "volume"].sum()
+            dn = g.loc[g["ret"] < 0, "volume"].sum()
+            return float(np.log((up + self.EPS) / (dn + self.EPS)))
+
+        value = df.groupby("symbol").apply(per_symbol)
+        out["value"] = out["symbol"].map(value)
+        return out
+
+
+feature = VolumeUpDownLogRatioFeature()


### PR DESCRIPTION
## Summary
- add up/down state metrics for bars and volume
- compute conditional next-return expectations and run length stats
- include sign-change and extreme-move reversal probabilities

## Testing
- `python -m py_compile cube2mat/features/up_bar_share.py cube2mat/features/down_bar_share.py cube2mat/features/up_mean_absret.py cube2mat/features/down_mean_absret.py cube2mat/features/up_down_absret_ratio.py cube2mat/features/volume_share_on_up.py cube2mat/features/volume_share_on_down.py cube2mat/features/volume_up_down_logratio.py cube2mat/features/time_share_above_vwap.py cube2mat/features/rv_share_above_vwap.py cube2mat/features/time_share_above_open.py cube2mat/features/next_ret_cond_up.py cube2mat/features/next_ret_cond_down.py cube2mat/features/cond_diff_next_ret_up_minus_down.py cube2mat/features/max_up_run_len.py cube2mat/features/max_down_run_len.py cube2mat/features/mean_volume_per_trade_up.py cube2mat/features/mean_volume_per_trade_down.py cube2mat/features/mvpt_up_over_down_ratio.py cube2mat/features/premium_close_vwap_up_minus_down.py cube2mat/features/range_up_down_ratio.py cube2mat/features/sign_change_rate.py cube2mat/features/reversal_prob_after_big_up.py cube2mat/features/reversal_prob_after_big_down.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a17dba0648832aa37533847301ca7a