### PR TITLE
Add intraday volatility, path geometry, seasonality, and trend features

### DIFF
--- a/cube2mat/features/absret_center_of_mass_time.py
+++ b/cube2mat/features/absret_center_of_mass_time.py
@@ -1,0 +1,74 @@
+# features/absret_center_of_mass_time.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class AbsRetCenterOfMassTimeFeature(BaseFeature):
+    """Time center-of-mass using |log return| as weights."""
+
+    name = "absret_center_of_mass_time"
+    description = "Weighted time centroid by |log return| within RTH, normalized to [0,1]."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    TOTAL_MIN = (
+        pd.Timedelta("15:59:00") - pd.Timedelta("09:30:00")
+    ).total_seconds() / 60.0
+
+    def _start(self, idx: pd.DatetimeIndex) -> pd.Timestamp:
+        day = idx[0].date()
+        tz = idx.tz
+        return pd.Timestamp.combine(day, dt.time(9, 30)).tz_localize(tz)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = (
+            self.ensure_et_index(full, "time", ctx.tz)
+            .between_time("09:30", "15:59")
+        )
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        res = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            g = g.sort_index()
+            r = (
+                np.log(g["close"])
+                .diff()
+                .replace([np.inf, -np.inf], np.nan)
+            )
+            start = self._start(g.index)
+            tf = ((g.index - start).total_seconds() / 60.0) / self.TOTAL_MIN
+            dfw = pd.DataFrame({"tf": tf.iloc[1:], "a": r.abs()}).dropna()
+            if len(dfw) < 3:
+                res[sym] = np.nan
+                continue
+            asum = float(dfw["a"].sum())
+            if not np.isfinite(asum) or asum <= 0:
+                res[sym] = np.nan
+                continue
+            val = float((dfw["tf"] * dfw["a"]).sum() / asum)
+            res[sym] = float(np.clip(val, 0.0, 1.0))
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = AbsRetCenterOfMassTimeFeature()

--- a/cube2mat/features/breakout_nextret_high.py
+++ b/cube2mat/features/breakout_nextret_high.py
@@ -1,0 +1,51 @@
+# features/breakout_nextret_high.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class BreakoutNextRetHighFeature(BaseFeature):
+    """Mean next simple return conditional on a 'new high' breakout event."""
+
+    name = "breakout_nextret_high"
+    description = "Mean(next simple ret | new session high at t) within RTH."
+    required_full_columns = ("symbol", "time", "high", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = (
+            self.ensure_et_index(full, "time", ctx.tz)
+            .between_time("09:30", "15:59")
+        )
+        df = df[df["symbol"].isin(sample["symbol"].unique())].copy()
+        df["high"] = pd.to_numeric(df["high"], errors="coerce")
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["high", "close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        res = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            g = g.sort_index()
+            prev_high = g["high"].shift(1).cummax()
+            event = (g["high"] > prev_high) & prev_high.notna()
+            next_ret = g["close"].pct_change().shift(-1)
+            vals = next_ret[event].dropna()
+            res[sym] = float(vals.mean()) if len(vals) >= 3 else np.nan
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = BreakoutNextRetHighFeature()

--- a/cube2mat/features/breakout_nextret_low.py
+++ b/cube2mat/features/breakout_nextret_low.py
@@ -1,0 +1,51 @@
+# features/breakout_nextret_low.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class BreakoutNextRetLowFeature(BaseFeature):
+    """Mean next simple return conditional on a 'new low' breakout event."""
+
+    name = "breakout_nextret_low"
+    description = "Mean(next simple ret | new session low at t) within RTH."
+    required_full_columns = ("symbol", "time", "low", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = (
+            self.ensure_et_index(full, "time", ctx.tz)
+            .between_time("09:30", "15:59")
+        )
+        df = df[df["symbol"].isin(sample["symbol"].unique())].copy()
+        df["low"] = pd.to_numeric(df["low"], errors="coerce")
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["low", "close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        res = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            g = g.sort_index()
+            prev_low = g["low"].shift(1).cummin()
+            event = (g["low"] < prev_low) & prev_low.notna()
+            next_ret = g["close"].pct_change().shift(-1)
+            vals = next_ret[event].dropna()
+            res[sym] = float(vals.mean()) if len(vals) >= 3 else np.nan
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = BreakoutNextRetLowFeature()

--- a/cube2mat/features/count_extreme_k_sigma.py
+++ b/cube2mat/features/count_extreme_k_sigma.py
@@ -1,0 +1,65 @@
+# features/count_extreme_k_sigma.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class CountExtremeKSigmaFeature(BaseFeature):
+    """Count of extreme simple returns where |ret| > k * sigma_robust."""
+
+    name = "count_extreme_k_sigma"
+    description = "Count of bars with |ret| exceeding k·σ_robust (σ from IQR) within RTH."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+    k = 3.0
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = (
+            self.ensure_et_index(full, "time", ctx.tz)
+            .between_time("09:30", "15:59")
+        )
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        k = self.k
+        res = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            r = (
+                g.sort_index()["close"].pct_change()
+                .replace([np.inf, -np.inf], np.nan)
+                .dropna()
+            )
+            if len(r) < 3:
+                res[sym] = np.nan
+                continue
+            q1, q3 = r.quantile([0.25, 0.75])
+            iqr = float(q3 - q1)
+            sigma = 0.7413 * iqr if iqr > 0 else float(r.std(ddof=1))
+            if not np.isfinite(sigma) or sigma <= 0:
+                res[sym] = np.nan
+                continue
+            cnt = int((r.abs() > (k * sigma)).sum())
+            res[sym] = float(cnt)
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = CountExtremeKSigmaFeature()

--- a/cube2mat/features/intraday_max_drawdown_close.py
+++ b/cube2mat/features/intraday_max_drawdown_close.py
@@ -1,0 +1,58 @@
+# features/intraday_max_drawdown_close.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class IntradayMaxDrawdownCloseFeature(BaseFeature):
+    """Max drawdown of close within 09:30–15:59, as a fraction."""
+
+    name = "intraday_max_drawdown_close"
+    description = "Session max drawdown (fraction) computed from close during RTH."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = (
+            self.ensure_et_index(full, "time", ctx.tz)
+            .between_time("09:30", "15:59")
+        )
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        res = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            s = g.sort_index()["close"]
+            if (s <= 0).any() or len(s) < 2:
+                res[sym] = np.nan
+                continue
+            roll_max = s.cummax()
+            ratio = (s / roll_max).replace([np.inf, -np.inf], np.nan).dropna()
+            if ratio.empty:
+                res[sym] = np.nan
+                continue
+            mdd = 1.0 - float(ratio.min())
+            res[sym] = mdd if mdd >= 0 else np.nan
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = IntradayMaxDrawdownCloseFeature()

--- a/cube2mat/features/max_absret_value.py
+++ b/cube2mat/features/max_absret_value.py
@@ -1,0 +1,54 @@
+# features/max_absret_value.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class MaxAbsRetValueFeature(BaseFeature):
+    """Max absolute simple return within 09:30–15:59."""
+
+    name = "max_absret_value"
+    description = "Session max |simple return| in RTH."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = (
+            self.ensure_et_index(full, "time", ctx.tz)
+            .between_time("09:30", "15:59")
+        )
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        res = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            r = (
+                g.sort_index()["close"].pct_change()
+                .replace([np.inf, -np.inf], np.nan)
+                .abs()
+                .dropna()
+            )
+            res[sym] = float(r.max()) if len(r) >= 1 else np.nan
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = MaxAbsRetValueFeature()

--- a/cube2mat/features/near_high_time_share_10bp.py
+++ b/cube2mat/features/near_high_time_share_10bp.py
@@ -1,0 +1,54 @@
+# features/near_high_time_share_10bp.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class NearHighTimeShare10bpFeature(BaseFeature):
+    """Share of bars where close is within 10 bp of the session HIGH."""
+
+    name = "near_high_time_share_10bp"
+    description = "Fraction of bars with close near session HIGH within 10bp."
+    required_full_columns = ("symbol", "time", "close", "high")
+    required_pv_columns = ("symbol",)
+    bp = 10
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = (
+            self.ensure_et_index(full, "time", ctx.tz)
+            .between_time("09:30", "15:59")
+        )
+        df = df[df["symbol"].isin(sample["symbol"].unique())].copy()
+        for c in ("close", "high"):
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+        df = df.dropna(subset=["close", "high"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        thr = self.bp / 10000.0
+        res = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            g = g.sort_index()
+            H = float(g["high"].max())
+            if not np.isfinite(H) or H <= 0 or len(g) < 1:
+                res[sym] = np.nan
+                continue
+            share = float(((H - g["close"]).clip(lower=0) / H <= thr).mean())
+            res[sym] = share
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = NearHighTimeShare10bpFeature()

--- a/cube2mat/features/near_low_time_share_10bp.py
+++ b/cube2mat/features/near_low_time_share_10bp.py
@@ -1,0 +1,54 @@
+# features/near_low_time_share_10bp.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class NearLowTimeShare10bpFeature(BaseFeature):
+    """Share of bars where close is within 10 bp of the session LOW."""
+
+    name = "near_low_time_share_10bp"
+    description = "Fraction of bars with close near session LOW within 10bp."
+    required_full_columns = ("symbol", "time", "close", "low")
+    required_pv_columns = ("symbol",)
+    bp = 10
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = (
+            self.ensure_et_index(full, "time", ctx.tz)
+            .between_time("09:30", "15:59")
+        )
+        df = df[df["symbol"].isin(sample["symbol"].unique())].copy()
+        for c in ("close", "low"):
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+        df = df.dropna(subset=["close", "low"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        thr = self.bp / 10000.0
+        res = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            g = g.sort_index()
+            L = float(g["low"].min())
+            if not np.isfinite(L) or L <= 0 or len(g) < 1:
+                res[sym] = np.nan
+                continue
+            share = float(((g["close"] - L).clip(lower=0) / L <= thr).mean())
+            res[sym] = share
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = NearLowTimeShare10bpFeature()

--- a/cube2mat/features/new_high_count.py
+++ b/cube2mat/features/new_high_count.py
@@ -1,0 +1,50 @@
+# features/new_high_count.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class NewHighCountFeature(BaseFeature):
+    """Count of times a new session HIGH is set in 09:30–15:59."""
+
+    name = "new_high_count"
+    description = "Number of new intraday highs within 09:30–15:59."
+    required_full_columns = ("symbol", "time", "high")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = (
+            self.ensure_et_index(full, "time", ctx.tz)
+            .between_time("09:30", "15:59")
+        )
+        df = df[df["symbol"].isin(sample["symbol"].unique())].copy()
+        df["high"] = pd.to_numeric(df["high"], errors="coerce")
+        df = df.dropna(subset=["high"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        res = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            h = g.sort_index()["high"]
+            if len(h) < 2:
+                res[sym] = np.nan
+                continue
+            prev_cum = h.shift(1).cummax()
+            res[sym] = float(((h > prev_cum) & prev_cum.notna()).sum())
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = NewHighCountFeature()

--- a/cube2mat/features/new_low_count.py
+++ b/cube2mat/features/new_low_count.py
@@ -1,0 +1,50 @@
+# features/new_low_count.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class NewLowCountFeature(BaseFeature):
+    """Count of times a new session LOW is set in 09:30–15:59."""
+
+    name = "new_low_count"
+    description = "Number of new intraday lows within 09:30–15:59."
+    required_full_columns = ("symbol", "time", "low")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = (
+            self.ensure_et_index(full, "time", ctx.tz)
+            .between_time("09:30", "15:59")
+        )
+        df = df[df["symbol"].isin(sample["symbol"].unique())].copy()
+        df["low"] = pd.to_numeric(df["low"], errors="coerce")
+        df = df.dropna(subset=["low"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        res = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            l = g.sort_index()["low"]
+            if len(l) < 2:
+                res[sym] = np.nan
+                continue
+            prev_cum = l.shift(1).cummin()
+            res[sym] = float(((l < prev_cum) & prev_cum.notna()).sum())
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = NewLowCountFeature()

--- a/cube2mat/features/rv_front_loading_score.py
+++ b/cube2mat/features/rv_front_loading_score.py
@@ -1,0 +1,89 @@
+# features/rv_front_loading_score.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class RVFrontLoadingScoreFeature(BaseFeature):
+    """Front-loading score for realized variance r^2."""
+
+    name = "rv_front_loading_score"
+    description = "2*AUC(cum RV fraction vs time fraction)-1 within RTH."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    TOTAL_MIN = (
+        pd.Timedelta("15:59:00") - pd.Timedelta("09:30:00")
+    ).total_seconds() / 60.0
+
+    def _start(self, idx: pd.DatetimeIndex) -> pd.Timestamp:
+        day = idx[0].date()
+        tz = idx.tz
+        return pd.Timestamp.combine(day, dt.time(9, 30)).tz_localize(tz)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = (
+            self.ensure_et_index(full, "time", ctx.tz)
+            .between_time("09:30", "15:59")
+        )
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        res = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            g = g.sort_index()
+            r = (
+                np.log(g["close"])
+                .diff()
+                .replace([np.inf, -np.inf], np.nan)
+                .dropna()
+            )
+            if len(r) < 3:
+                res[sym] = np.nan
+                continue
+            rsq = r * r
+            total = float(rsq.sum())
+            if not np.isfinite(total) or total <= 0:
+                res[sym] = np.nan
+                continue
+            start = self._start(g.index)
+            x = ((g.index - start).total_seconds() / 60.0) / self.TOTAL_MIN
+            x = x.iloc[1:]
+            y = rsq.cumsum() / total
+            x_arr = x.to_numpy()
+            y_arr = y.to_numpy()
+            if x_arr.size < 2:
+                res[sym] = np.nan
+                continue
+            if x_arr[0] > 0:
+                x_arr = np.insert(x_arr, 0, 0.0)
+                y_arr = np.insert(y_arr, 0, 0.0)
+            if x_arr[-1] < 1.0:
+                x_arr = np.append(x_arr, 1.0)
+                y_arr = np.append(y_arr, 1.0)
+            auc = float(np.trapz(y_arr, x_arr))
+            score = 2.0 * auc - 1.0
+            res[sym] = float(np.clip(score, -1.0, 1.0))
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = RVFrontLoadingScoreFeature()

--- a/cube2mat/features/rv_logret_30m.py
+++ b/cube2mat/features/rv_logret_30m.py
@@ -1,0 +1,53 @@
+# features/rv_logret_30m.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class RVLogret30mFeature(BaseFeature):
+    """RV on 30-minute resampled close (last in bin) within 09:30–15:59."""
+
+    name = "rv_logret_30m"
+    description = "Realized variance using log returns on 30-minute resampled close in 09:30–15:59."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = (
+            self.ensure_et_index(full, "time", ctx.tz)
+            .between_time("09:30", "15:59")
+        )
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        res = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            s = g.sort_index()["close"].resample("30T").last().dropna()
+            if len(s) < 3:
+                res[sym] = np.nan
+                continue
+            r = np.log(s).diff().replace([np.inf, -np.inf], np.nan).dropna()
+            res[sym] = float((r * r).sum()) if len(r) >= 2 else np.nan
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = RVLogret30mFeature()

--- a/cube2mat/features/time_share_above_twap.py
+++ b/cube2mat/features/time_share_above_twap.py
@@ -1,0 +1,53 @@
+# features/time_share_above_twap.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class TimeShareAboveTWAPFeature(BaseFeature):
+    """Fraction of bars with close > TWAP (mean close) in 09:30–15:59."""
+
+    name = "time_share_above_twap"
+    description = "Share of bars where close > TWAP during RTH."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = (
+            self.ensure_et_index(full, "time", ctx.tz)
+            .between_time("09:30", "15:59")
+        )
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        res = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            g = g.sort_index()
+            if len(g) < 2:
+                res[sym] = np.nan
+                continue
+            twap = float(g["close"].mean())
+            res[sym] = float((g["close"] > twap).mean())
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = TimeShareAboveTWAPFeature()

--- a/cube2mat/features/trend_piecewise_slope_am_pm.py
+++ b/cube2mat/features/trend_piecewise_slope_am_pm.py
@@ -1,0 +1,68 @@
+# features/trend_piecewise_slope_am_pm.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class TrendPiecewiseSlopeAmPmFeature(BaseFeature):
+    """Difference between afternoon and morning linear slopes."""
+
+    name = "trend_piecewise_slope_am_pm"
+    description = "Afternoon minus morning OLS slope of close~time within RTH."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def _ols_slope(self, y: pd.Series) -> float:
+        n = y.size
+        if n < 2:
+            return np.nan
+        t = np.linspace(0.0, 1.0, n, endpoint=True)
+        x = t - t.mean()
+        y_d = y.to_numpy(dtype=float) - y.mean()
+        den = (x * x).sum()
+        if den <= 0:
+            return np.nan
+        return float((x * y_d).sum() / den)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, ["symbol", "time", "close"])
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = (
+            self.ensure_et_index(full, "time", ctx.tz)
+            .between_time("09:30", "15:59")
+        )
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"]).sort_index()
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        am = df.between_time("09:30", "12:00")
+        pm = df.between_time("12:00", "15:59")
+
+        res = {}
+        for sym in sample["symbol"].unique():
+            ya = am[am["symbol"] == sym]["close"]
+            yp = pm[pm["symbol"] == sym]["close"]
+            if ya.size < 2 or yp.size < 2:
+                res[sym] = np.nan
+                continue
+            res[sym] = self._ols_slope(yp) - self._ols_slope(ya)
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = TrendPiecewiseSlopeAmPmFeature()

--- a/cube2mat/features/trend_quad_beta1.py
+++ b/cube2mat/features/trend_quad_beta1.py
@@ -1,0 +1,56 @@
+# features/trend_quad_beta1.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class TrendQuadBeta1Feature(BaseFeature):
+    """OLS coefficient of t (linear term) in close ~ 1 + t + t^2, with t in [0,1]."""
+
+    name = "trend_quad_beta1"
+    description = "Linear coefficient (beta1) of quadratic trend close~1+t+t^2 in RTH."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, ["symbol", "time", "close"])
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        res = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            y = g.sort_index()["close"].to_numpy(dtype=float)
+            n = y.size
+            if n < 3:
+                res[sym] = np.nan
+                continue
+            t = np.linspace(0.0, 1.0, n, endpoint=True)
+            X = np.column_stack([np.ones(n), t, t * t])
+            try:
+                beta, *_ = np.linalg.lstsq(X, y, rcond=None)
+                res[sym] = float(beta[1])
+            except Exception:
+                res[sym] = np.nan
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = TrendQuadBeta1Feature()

--- a/cube2mat/features/trend_quad_beta2.py
+++ b/cube2mat/features/trend_quad_beta2.py
@@ -1,0 +1,56 @@
+# features/trend_quad_beta2.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class TrendQuadBeta2Feature(BaseFeature):
+    """OLS coefficient of t^2 (quadratic term) in close ~ 1 + t + t^2."""
+
+    name = "trend_quad_beta2"
+    description = "Quadratic coefficient (beta2) of close~1+t+t^2 in RTH."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, ["symbol", "time", "close"])
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        res = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            y = g.sort_index()["close"].to_numpy(dtype=float)
+            n = y.size
+            if n < 3:
+                res[sym] = np.nan
+                continue
+            t = np.linspace(0.0, 1.0, n, endpoint=True)
+            X = np.column_stack([np.ones(n), t, t * t])
+            try:
+                beta, *_ = np.linalg.lstsq(X, y, rcond=None)
+                res[sym] = float(beta[2])
+            except Exception:
+                res[sym] = np.nan
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = TrendQuadBeta2Feature()

--- a/cube2mat/features/trend_resid_kurt.py
+++ b/cube2mat/features/trend_resid_kurt.py
@@ -1,0 +1,74 @@
+# features/trend_resid_kurt.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class TrendResidKurtFeature(BaseFeature):
+    """Adjusted excess kurtosis of residuals from close ~ time in RTH."""
+
+    name = "trend_resid_kurt"
+    description = "Adjusted excess kurtosis of residuals from linear trend close~time in RTH."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def _lin_fit_resid(self, y: np.ndarray) -> np.ndarray:
+        n = y.size
+        t = np.linspace(0.0, 1.0, n, endpoint=True)
+        X = np.column_stack([np.ones(n), t])
+        beta, *_ = np.linalg.lstsq(X, y, rcond=None)
+        return y - X @ beta
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, ["symbol", "time", "close"])
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        res = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            y = g.sort_index()["close"].to_numpy(dtype=float)
+            n = y.size
+            if n < 4:
+                res[sym] = np.nan
+                continue
+            try:
+                e = self._lin_fit_resid(y)
+            except Exception:
+                res[sym] = np.nan
+                continue
+            m = e.mean()
+            c2 = np.mean((e - m) ** 2)
+            if c2 <= 0:
+                res[sym] = np.nan
+                continue
+            c4 = np.mean((e - m) ** 4)
+            g2 = c4 / (c2 * c2) - 3.0
+            adj = (
+                (n - 1) / ((n - 2) * (n - 3)) * ((n + 1) * g2 + 6.0)
+                if n > 3
+                else np.nan
+            )
+            res[sym] = float(adj) if np.isfinite(adj) else np.nan
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = TrendResidKurtFeature()

--- a/cube2mat/features/trend_resid_skew.py
+++ b/cube2mat/features/trend_resid_skew.py
@@ -1,0 +1,70 @@
+# features/trend_resid_skew.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class TrendResidSkewFeature(BaseFeature):
+    """Adjusted skewness of residuals from close ~ time (t in [0,1]) in RTH."""
+
+    name = "trend_resid_skew"
+    description = "Adjusted skewness of residuals from linear trend close~time in RTH."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def _lin_fit_resid(self, y: np.ndarray) -> np.ndarray:
+        n = y.size
+        t = np.linspace(0.0, 1.0, n, endpoint=True)
+        X = np.column_stack([np.ones(n), t])
+        beta, *_ = np.linalg.lstsq(X, y, rcond=None)
+        return y - X @ beta
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, ["symbol", "time", "close"])
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        res = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            y = g.sort_index()["close"].to_numpy(dtype=float)
+            n = y.size
+            if n < 3:
+                res[sym] = np.nan
+                continue
+            try:
+                e = self._lin_fit_resid(y)
+            except Exception:
+                res[sym] = np.nan
+                continue
+            m = e.mean()
+            c2 = np.mean((e - m) ** 2)
+            if c2 <= 0:
+                res[sym] = np.nan
+                continue
+            c3 = np.mean((e - m) ** 3)
+            g1 = c3 / (c2 ** 1.5)
+            adj = np.sqrt(n * (n - 1)) / (n - 2) if n > 2 else np.nan
+            res[sym] = float(adj * g1) if np.isfinite(adj) else np.nan
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = TrendResidSkewFeature()

--- a/cube2mat/features/u_shape_corr_absret.py
+++ b/cube2mat/features/u_shape_corr_absret.py
@@ -1,0 +1,77 @@
+# features/u_shape_corr_absret.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class UShapeCorrAbsRetFeature(BaseFeature):
+    """Pearson correlation between |log return| and a U-shape template over RTH bars."""
+
+    name = "u_shape_corr_absret"
+    description = "Correlation of |log return| with U-shape time template."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def _template(self, n: int) -> np.ndarray:
+        t = np.linspace(0.0, 1.0, n, endpoint=True)
+        u = (t - 0.5) ** 2
+        std = u.std(ddof=1)
+        u = (u - u.mean()) / (std if std > 0 else 1.0)
+        return u
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = (
+            self.ensure_et_index(full, "time", ctx.tz)
+            .between_time("09:30", "15:59")
+        )
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        res = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            r = (
+                np.log(g.sort_index()["close"])
+                .diff()
+                .replace([np.inf, -np.inf], np.nan)
+                .dropna()
+                .abs()
+            )
+            if len(r) < 3:
+                res[sym] = np.nan
+                continue
+            x = r.to_numpy(dtype=float)
+            x = x - x.mean()
+            sx = np.sqrt((x * x).sum())
+            if not np.isfinite(sx) or sx == 0:
+                res[sym] = np.nan
+                continue
+            u = self._template(len(x))
+            su = np.sqrt((u * u).sum())
+            if su == 0:
+                res[sym] = np.nan
+                continue
+            corr = float(np.dot(x, u) / (sx * su))
+            res[sym] = corr
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = UShapeCorrAbsRetFeature()

--- a/cube2mat/features/u_shape_corr_volume.py
+++ b/cube2mat/features/u_shape_corr_volume.py
@@ -1,0 +1,71 @@
+# features/u_shape_corr_volume.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class UShapeCorrVolumeFeature(BaseFeature):
+    """Pearson correlation between volume and a U-shape template over RTH bars."""
+
+    name = "u_shape_corr_volume"
+    description = "Correlation of volume with U-shape time template (early/late high)."
+    required_full_columns = ("symbol", "time", "volume")
+    required_pv_columns = ("symbol",)
+
+    def _template(self, n: int) -> np.ndarray:
+        t = np.linspace(0.0, 1.0, n, endpoint=True)
+        u = (t - 0.5) ** 2
+        std = u.std(ddof=1)
+        u = (u - u.mean()) / (std if std > 0 else 1.0)
+        return u
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = (
+            self.ensure_et_index(full, "time", ctx.tz)
+            .between_time("09:30", "15:59")
+        )
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+        df["volume"] = pd.to_numeric(df["volume"], errors="coerce")
+        df = df.dropna(subset=["volume"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        res = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            v = g.sort_index()["volume"]
+            if len(v) < 3:
+                res[sym] = np.nan
+                continue
+            x = v.to_numpy(dtype=float)
+            x = x - x.mean()
+            sx = np.sqrt((x * x).sum())
+            if not np.isfinite(sx) or sx == 0:
+                res[sym] = np.nan
+                continue
+            u = self._template(len(x))
+            su = np.sqrt((u * u).sum())
+            if su == 0:
+                res[sym] = np.nan
+                continue
+            corr = float(np.dot(x, u) / (sx * su))
+            res[sym] = corr
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = UShapeCorrVolumeFeature()

--- a/cube2mat/features/ulcer_index_close.py
+++ b/cube2mat/features/ulcer_index_close.py
@@ -1,0 +1,55 @@
+# features/ulcer_index_close.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class UlcerIndexCloseFeature(BaseFeature):
+    """Ulcer Index (RMS of drawdowns) for close within 09:30–15:59."""
+
+    name = "ulcer_index_close"
+    description = "Ulcer Index based on close drawdowns in RTH (fraction, not %)."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = (
+            self.ensure_et_index(full, "time", ctx.tz)
+            .between_time("09:30", "15:59")
+        )
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        res = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            s = g.sort_index()["close"]
+            if (s <= 0).any() or len(s) < 2:
+                res[sym] = np.nan
+                continue
+            roll_max = s.cummax()
+            dd = 1.0 - (s / roll_max)
+            dd = dd.clip(lower=0).replace([np.inf, -np.inf], np.nan).dropna()
+            res[sym] = float(np.sqrt((dd * dd).mean())) if len(dd) >= 1 else np.nan
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = UlcerIndexCloseFeature()

--- a/cube2mat/features/variance_ratio_q10.py
+++ b/cube2mat/features/variance_ratio_q10.py
@@ -1,0 +1,68 @@
+# features/variance_ratio_q10.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class VarianceRatioQ10Feature(BaseFeature):
+    """Variance Ratio with horizon q=10 on intraday log returns, 09:30–15:59."""
+
+    name = "variance_ratio_q10"
+    description = "Variance Ratio of intraday log returns with q=10 in 09:30–15:59."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+    q = 10
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = (
+            self.ensure_et_index(full, "time", ctx.tz)
+            .between_time("09:30", "15:59")
+        )
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        res = {}
+        q = self.q
+        for sym, g in df.groupby("symbol", sort=False):
+            s = (
+                np.log(g.sort_index()["close"])
+                .diff()
+                .replace([np.inf, -np.inf], np.nan)
+                .dropna()
+            )
+            if len(s) < q + 2:
+                res[sym] = np.nan
+                continue
+            var1 = s.var(ddof=1)
+            if not np.isfinite(var1) or var1 <= 0:
+                res[sym] = np.nan
+                continue
+            roll = s.rolling(q).sum().dropna()
+            if len(roll) < 2:
+                res[sym] = np.nan
+                continue
+            varq = roll.var(ddof=1)
+            res[sym] = float(varq / (q * var1)) if np.isfinite(varq) and varq >= 0 else np.nan
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = VarianceRatioQ10Feature()

--- a/cube2mat/features/variance_ratio_q2.py
+++ b/cube2mat/features/variance_ratio_q2.py
@@ -1,0 +1,72 @@
+# features/variance_ratio_q2.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class VarianceRatioQ2Feature(BaseFeature):
+    """
+    Variance Ratio with horizon q=2 on intraday log returns within 09:30–15:59.
+
+    VR(q) = Var(sum_{i=0..q-1} r_{t+i}) / (q * Var(r_t)); NaN if insufficient or Var(r_t)=0.
+    """
+
+    name = "variance_ratio_q2"
+    description = "Variance Ratio of intraday log returns with q=2 in 09:30–15:59."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+    q = 2
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = (
+            self.ensure_et_index(full, "time", ctx.tz)
+            .between_time("09:30", "15:59")
+        )
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        res = {}
+        q = self.q
+        for sym, g in df.groupby("symbol", sort=False):
+            s = (
+                np.log(g.sort_index()["close"])
+                .diff()
+                .replace([np.inf, -np.inf], np.nan)
+                .dropna()
+            )
+            if len(s) < q + 2:
+                res[sym] = np.nan
+                continue
+            var1 = s.var(ddof=1)
+            if not np.isfinite(var1) or var1 <= 0:
+                res[sym] = np.nan
+                continue
+            roll = s.rolling(q).sum().dropna()
+            if len(roll) < 2:
+                res[sym] = np.nan
+                continue
+            varq = roll.var(ddof=1)
+            res[sym] = float(varq / (q * var1)) if np.isfinite(varq) and varq >= 0 else np.nan
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = VarianceRatioQ2Feature()

--- a/cube2mat/features/volume_center_of_mass_time.py
+++ b/cube2mat/features/volume_center_of_mass_time.py
@@ -1,0 +1,69 @@
+# features/volume_center_of_mass_time.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class VolumeCenterOfMassTimeFeature(BaseFeature):
+    """Time center-of-mass (in [0,1]) using volume as weights."""
+
+    name = "volume_center_of_mass_time"
+    description = "Weighted time centroid by volume in RTH, normalized to [0,1]."
+    required_full_columns = ("symbol", "time", "volume")
+    required_pv_columns = ("symbol",)
+
+    TOTAL_MIN = (
+        pd.Timedelta("15:59:00") - pd.Timedelta("09:30:00")
+    ).total_seconds() / 60.0
+
+    def _start(self, idx: pd.DatetimeIndex) -> pd.Timestamp:
+        day = idx[0].date()
+        tz = idx.tz
+        return pd.Timestamp.combine(day, dt.time(9, 30)).tz_localize(tz)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = (
+            self.ensure_et_index(full, "time", ctx.tz)
+            .between_time("09:30", "15:59")
+        )
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+        df["volume"] = pd.to_numeric(df["volume"], errors="coerce")
+        df = df.dropna(subset=["volume"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        res = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            g = g.sort_index()
+            if len(g) < 2:
+                res[sym] = np.nan
+                continue
+            start = self._start(g.index)
+            tfrac = ((g.index - start).total_seconds() / 60.0) / self.TOTAL_MIN
+            w = g["volume"]
+            wsum = float(w.sum())
+            if not np.isfinite(wsum) or wsum <= 0:
+                res[sym] = np.nan
+                continue
+            val = float((tfrac * w).sum() / wsum)
+            res[sym] = float(np.clip(val, 0.0, 1.0))
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = VolumeCenterOfMassTimeFeature()


### PR DESCRIPTION
## Summary
- add variance ratio (q=2 and q=10), 30m realized variance, and TWAP comparison metrics
- implement extreme move and breakout-derived path geometry statistics
- introduce seasonality and trend curvature features such as volume center of mass, U-shape correlations, and quadratic trend coefficients

## Testing
- `python cube2mat/runner_smoke_test.py --date 2024-01-02 --only variance_ratio_q2 --pv-dir /tmp/pv --full-dir /tmp/full` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas numpy` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ea658c14832a8b468079df18ba3a