### PR TITLE
Add correlation, candlestick, and path efficiency features

### DIFF
--- a/cube2mat/features/ac_ret_lag2.py
+++ b/cube2mat/features/ac_ret_lag2.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+def _acf_at_lag(x: np.ndarray, k: int) -> float:
+    x = np.asarray(x, dtype=float)
+    n = x.size
+    if n < k + 2:
+        return np.nan
+    m = x.mean()
+    xc = x - m
+    den = float(np.sum(xc * xc))
+    if den <= 0 or not np.isfinite(den):
+        return np.nan
+    num = float(np.sum(xc[k:] * xc[:-k]))
+    return num / den
+
+class ACRetLag2Feature(BaseFeature):
+    """
+    Autocorrelation of intraday log returns at lag=2 within 09:30–15:59.
+    """
+    name = "ac_ret_lag2"
+    description = "Lag-2 autocorrelation of intraday log returns in RTH."
+    required_full_columns = ("symbol","time","close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx,date,list(self.required_full_columns))
+        sample = self.load_pv(ctx,date,list(self.required_pv_columns))
+        if df is None or sample is None: return None
+        out = sample[["symbol"]].copy()
+        if df.empty or sample.empty: out["value"]=pd.NA; return out
+        df = self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59")
+        df = df[df.symbol.isin(set(sample.symbol.unique()))].copy()
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty: out["value"]=pd.NA; return out
+        res = {}
+        for sym,g in df.groupby("symbol",sort=False):
+            r = np.log(g.sort_index()["close"]).diff().replace([np.inf,-np.inf],np.nan).dropna().to_numpy()
+            res[sym] = float(_acf_at_lag(r, 2))
+        out["value"] = out["symbol"].map(res)
+        return out
+
+feature = ACRetLag2Feature()

--- a/cube2mat/features/ac_ret_lag5.py
+++ b/cube2mat/features/ac_ret_lag5.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+from cube2mat.features.ac_ret_lag2 import _acf_at_lag
+
+class ACRetLag5Feature(BaseFeature):
+    """
+    Autocorrelation of intraday log returns at lag=5 within 09:30–15:59.
+    """
+    name = "ac_ret_lag5"
+    description = "Lag-5 autocorrelation of intraday log returns in RTH."
+    required_full_columns = ("symbol","time","close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx,date,list(self.required_full_columns))
+        sample = self.load_pv(ctx,date,list(self.required_pv_columns))
+        if df is None or sample is None: return None
+        out = sample[["symbol"]].copy()
+        if df.empty or sample.empty: out["value"]=pd.NA; return out
+        df = self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59")
+        df = df[df.symbol.isin(set(sample.symbol.unique()))].copy()
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty: out["value"]=pd.NA; return out
+        res = {}
+        for sym,g in df.groupby("symbol",sort=False):
+            r = np.log(g.sort_index()["close"]).diff().replace([np.inf,-np.inf],np.nan).dropna().to_numpy()
+            res[sym] = float(_acf_at_lag(r, 5))
+        out["value"] = out["symbol"].map(res)
+        return out
+
+feature = ACRetLag5Feature()

--- a/cube2mat/features/doji_density.py
+++ b/cube2mat/features/doji_density.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class DojiDensityFeature(BaseFeature):
+    """
+    Share of bars with |close-open| <= theta*(high-low), theta=0.1; exclude zero-range bars.
+    """
+    name = "doji_density"
+    description = "Doji density in RTH with theta=0.1 threshold; exclude zero-range bars."
+    required_full_columns = ("symbol","time","open","high","low","close")
+    required_pv_columns = ("symbol",)
+    theta = 0.1
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df=self.load_full(ctx,date,list(self.required_full_columns))
+        sample=self.load_pv(ctx,date,list(self.required_pv_columns))
+        if df is None or sample is None:return None
+        out=sample[["symbol"]].copy()
+        if df.empty or sample.empty: out["value"]=pd.NA; return out
+        df=self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59")
+        df=df[df.symbol.isin(set(sample.symbol.unique()))]
+        if df.empty: out["value"]=pd.NA; return out
+        for c in ("open","high","low","close"): df[c]=pd.to_numeric(df[c],errors="coerce")
+        df=df.dropna(subset=["open","high","low","close"])
+        if df.empty: out["value"]=pd.NA; return out
+
+        rng = (df["high"]-df["low"])
+        body = (df["close"]-df["open"]).abs()
+        df2 = df.assign(rng=rng, body=body)
+        df2 = df2[df2["rng"]>0]
+        th = float(self.theta)
+        res = df2.groupby("symbol").apply(lambda g: float((g["body"] <= th*g["rng"]).mean()) if len(g)>0 else np.nan)
+        out["value"]=out["symbol"].map(res); return out
+
+feature = DojiDensityFeature()

--- a/cube2mat/features/hurst_rs_ret.py
+++ b/cube2mat/features/hurst_rs_ret.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+def _hurst_rs(x: np.ndarray) -> float:
+    x = np.asarray(x, dtype=float)
+    n = x.size
+    # candidate block sizes (minute级别会话 ~389；选择几何序)
+    sizes = [5, 10, 20, 40, 80, 160]
+    sizes = [m for m in sizes if m <= n // 2 and m >= 5]
+    RS_pts = []
+    for m in sizes:
+        k = n // m
+        if k < 1:
+            continue
+        rs_vals = []
+        for i in range(k):
+            seg = x[i*m:(i+1)*m]
+            seg = seg - seg.mean()
+            Z = np.cumsum(seg)
+            R = float(Z.max() - Z.min())
+            S = float(seg.std(ddof=1))
+            if S > 0 and np.isfinite(R) and np.isfinite(S):
+                rs_vals.append(R / S)
+        if len(rs_vals) > 0:
+            RS_pts.append((m, float(np.mean(rs_vals))))
+    if len(RS_pts) < 2:
+        return np.nan
+    logs = np.log([p[0] for p in RS_pts])
+    logr = np.log([p[1] for p in RS_pts])
+    try:
+        H = float(np.polyfit(logs, logr, 1)[0])
+    except Exception:
+        H = np.nan
+    return H
+
+class HurstRSRetFeature(BaseFeature):
+    """
+    Hurst exponent via R/S analysis on intraday log returns in RTH.
+    Uses block sizes {5,10,20,40,80,160} as available; OLS slope of log(R/S)~log(m).
+    """
+    name = "hurst_rs_ret"
+    description = "R/S Hurst exponent estimated from intraday log returns."
+    required_full_columns = ("symbol","time","close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df=self.load_full(ctx,date,["symbol","time","close"])
+        sample=self.load_pv(ctx,date,["symbol"])
+        if df is None or sample is None:return None
+        out=sample[["symbol"]].copy()
+        if df.empty or sample.empty: out["value"]=pd.NA; return out
+
+        df=self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59")
+        df=df[df.symbol.isin(set(sample.symbol.unique()))]
+        if df.empty: out["value"]=pd.NA; return out
+        df["close"]=pd.to_numeric(df["close"],errors="coerce"); df=df.dropna(subset=["close"])
+        if df.empty: out["value"]=pd.NA; return out
+
+        res={}
+        for sym,g in df.groupby("symbol",sort=False):
+            r = np.log(g.sort_index()["close"]).diff().replace([np.inf,-np.inf],np.nan).dropna().to_numpy()
+            if r.size < 20:
+                res[sym]=np.nan; continue
+            res[sym] = _hurst_rs(r)
+        out["value"]=out["symbol"].map(res); return out
+
+feature = HurstRSRetFeature()

--- a/cube2mat/features/ljung_box_q_5.py
+++ b/cube2mat/features/ljung_box_q_5.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+from cube2mat.features.ac_ret_lag2 import _acf_at_lag
+
+class LjungBoxQ5Feature(BaseFeature):
+    """
+    Ljung-Box Q statistic for log returns using lags 1..5:
+      Q = n(n+2) * sum_{k=1..5} rho_k^2 / (n-k)
+    Returns Q; NaN if n<=5 or any denominator invalid.
+    """
+    name = "ljung_box_q_5"
+    description = "Ljung-Box Q statistic at lags 1..5 for intraday log returns."
+    required_full_columns = ("symbol","time","close")
+    required_pv_columns = ("symbol",)
+    m = 5
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx,date,list(self.required_full_columns))
+        sample = self.load_pv(ctx,date,list(self.required_pv_columns))
+        if df is None or sample is None: return None
+        out = sample[["symbol"]].copy()
+        if df.empty or sample.empty: out["value"]=pd.NA; return out
+        df = self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59")
+        df = df[df.symbol.isin(set(sample.symbol.unique()))].copy()
+        df["close"]=pd.to_numeric(df["close"],errors="coerce")
+        df=df.dropna(subset=["close"])
+        if df.empty: out["value"]=pd.NA; return out
+
+        m = int(self.m); res={}
+        for sym,g in df.groupby("symbol",sort=False):
+            r = np.log(g.sort_index()["close"]).diff().replace([np.inf,-np.inf],np.nan).dropna().to_numpy()
+            n = r.size
+            if n <= m: res[sym]=np.nan; continue
+            q = 0.0; valid = True
+            for k in range(1, m+1):
+                rho = _acf_at_lag(r, k)
+                if not np.isfinite(rho) or (n - k) <= 0:
+                    valid = False; break
+                q += (rho*rho) / (n - k)
+            if not valid:
+                res[sym] = np.nan
+            else:
+                res[sym] = float(n * (n + 2) * q)
+        out["value"]=out["symbol"].map(res); return out
+
+feature = LjungBoxQ5Feature()

--- a/cube2mat/features/lower_shadow_ratio_mean.py
+++ b/cube2mat/features/lower_shadow_ratio_mean.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class LowerShadowRatioMeanFeature(BaseFeature):
+    """
+    Mean lower shadow ratio: (min(open,close) - low) / (high - low), exclude zero-range bars.
+    """
+    name = "lower_shadow_ratio_mean"
+    description = "Mean lower shadow / range ratio in RTH; exclude zero-range bars."
+    required_full_columns = ("symbol","time","open","high","low","close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df=self.load_full(ctx,date,list(self.required_full_columns))
+        sample=self.load_pv(ctx,date,list(self.required_pv_columns))
+        if df is None or sample is None:return None
+        out=sample[["symbol"]].copy()
+        if df.empty or sample.empty: out["value"]=pd.NA; return out
+        df=self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59")
+        df=df[df.symbol.isin(set(sample.symbol.unique()))]
+        if df.empty: out["value"]=pd.NA; return out
+        for c in ("open","high","low","close"): df[c]=pd.to_numeric(df[c],errors="coerce")
+        df=df.dropna(subset=["open","high","low","close"])
+        if df.empty: out["value"]=pd.NA; return out
+
+        rng=(df["high"]-df["low"])
+        lowsh=(np.minimum(df["open"],df["close"]) - df["low"]).clip(lower=0)
+        df2=df.assign(rng=rng, lowsh=lowsh)
+        df2=df2[df2["rng"]>0]
+        res=df2.groupby("symbol").apply(lambda g: float((g["lowsh"]/g["rng"]).mean()) if len(g)>0 else np.nan)
+        out["value"]=out["symbol"].map(res); return out
+
+feature = LowerShadowRatioMeanFeature()

--- a/cube2mat/features/marubozu_density.py
+++ b/cube2mat/features/marubozu_density.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class MarubozuDensityFeature(BaseFeature):
+    """
+    Share of 'marubozu-like' bars:
+      upper_shadow_ratio <= alpha AND lower_shadow_ratio <= alpha AND body_ratio >= beta
+    Defaults: alpha=0.10, beta=0.80; exclude zero-range bars.
+    """
+    name = "marubozu_density"
+    description = "Density of long-body, tiny-shadow bars (alpha=0.10, beta=0.80) in RTH."
+    required_full_columns = ("symbol","time","open","high","low","close")
+    required_pv_columns = ("symbol",)
+    alpha = 0.10
+    beta  = 0.80
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df=self.load_full(ctx,date,list(self.required_full_columns))
+        sample=self.load_pv(ctx,date,list(self.required_pv_columns))
+        if df is None or sample is None:return None
+        out=sample[["symbol"]].copy()
+        if df.empty or sample.empty: out["value"]=pd.NA; return out
+
+        df=self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59")
+        df=df[df.symbol.isin(set(sample.symbol.unique()))]
+        if df.empty: out["value"]=pd.NA; return out
+        for c in ("open","high","low","close"): df[c]=pd.to_numeric(df[c],errors="coerce")
+        df=df.dropna(subset=["open","high","low","close"])
+        if df.empty: out["value"]=pd.NA; return out
+
+        rng=(df["high"]-df["low"])
+        body=(df["close"]-df["open"]).abs()
+        up=(df["high"]-np.maximum(df["open"],df["close"])).clip(lower=0)
+        lowsh=(np.minimum(df["open"],df["close"]) - df["low"]).clip(lower=0)
+        df2=df.assign(rng=rng, body=body, up=up, lowsh=lowsh)
+        df2=df2[df2["rng"]>0]
+
+        a=float(self.alpha); b=float(self.beta)
+        cond = (df2["up"]/df2["rng"] <= a) & (df2["lowsh"]/df2["rng"] <= a) & (df2["body"]/df2["rng"] >= b)
+        res = df2.groupby("symbol").apply(lambda g: float(cond.loc[g.index].mean()) if len(g)>0 else np.nan)
+        out["value"]=out["symbol"].map(res); return out
+
+feature = MarubozuDensityFeature()

--- a/cube2mat/features/mean_body_to_range.py
+++ b/cube2mat/features/mean_body_to_range.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class MeanBodyToRangeFeature(BaseFeature):
+    """
+    Mean of |close-open| / (high-low) over RTH bars; exclude bars with (high-low)<=0.
+    """
+    name = "mean_body_to_range"
+    description = "Mean candlestick body-to-range ratio in RTH; exclude zero-range bars."
+    required_full_columns = ("symbol","time","open","high","low","close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df=self.load_full(ctx,date,list(self.required_full_columns))
+        sample=self.load_pv(ctx,date,list(self.required_pv_columns))
+        if df is None or sample is None:return None
+        out=sample[["symbol"]].copy()
+        if df.empty or sample.empty: out["value"]=pd.NA; return out
+        df=self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59")
+        df=df[df.symbol.isin(set(sample.symbol.unique()))]
+        if df.empty: out["value"]=pd.NA; return out
+        for c in ("open","high","low","close"): df[c]=pd.to_numeric(df[c],errors="coerce")
+        df=df.dropna(subset=["open","high","low","close"])
+        if df.empty: out["value"]=pd.NA; return out
+
+        rng = (df["high"] - df["low"])
+        body = (df["close"] - df["open"]).abs()
+        df2 = df.assign(rng=rng, body=body)
+        df2 = df2[df2["rng"] > 0]
+        res = df2.groupby("symbol").apply(lambda g: float((g["body"]/g["rng"]).mean()) if len(g)>0 else np.nan)
+        out["value"]=out["symbol"].map(res)
+        return out
+
+feature = MeanBodyToRangeFeature()

--- a/cube2mat/features/pac_ret_lag1_5.py
+++ b/cube2mat/features/pac_ret_lag1_5.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _acf(x: np.ndarray, m: int) -> np.ndarray:
+    x = np.asarray(x, dtype=float)
+    n = x.size
+    if n < m + 2:
+        return np.full(m+1, np.nan)
+    xc = x - x.mean()
+    den = float(np.sum(xc*xc))
+    if den <= 0 or not np.isfinite(den):
+        return np.full(m+1, np.nan)
+    r = np.empty(m+1, dtype=float)
+    for k in range(m+1):
+        r[k] = float(np.sum(xc[k:] * xc[:n-k])) / den
+    return r
+
+
+def _pacf_durbin_levinson(r: np.ndarray, m: int) -> np.ndarray:
+    # r: acf with r[0]=1; returns pacf[1..m]
+    pacf = np.zeros(m+1, dtype=float)
+    phi_prev = np.zeros(m+1, dtype=float)
+    v = 1.0
+    for k in range(1, m+1):
+        if k == 1:
+            phi = r[1]
+        else:
+            num = r[k] - np.sum(phi_prev[1:k] * r[1:k][::-1])
+            if v <= 0 or not np.isfinite(v):
+                phi = np.nan
+            else:
+                phi = num / v
+        pacf[k] = phi
+        # update phi_prev
+        if k > 1 and np.isfinite(phi):
+            phi_new = phi_prev.copy()
+            for j in range(1, k):
+                phi_new[j] = phi_prev[j] - phi * phi_prev[k-j]
+            phi_new[k] = phi
+            phi_prev = phi_new
+        else:
+            phi_prev[k] = phi
+        # update v
+        if np.isfinite(phi):
+            v = v * (1.0 - phi*phi)
+        else:
+            v = np.nan
+    return pacf
+
+
+class PACRetLag1to5Feature(BaseFeature):
+    """
+    Partial autocorrelation of log returns at lags 1..5 via Durbin-Levinson.
+    Output: index of the first significant lag in {1..5} (two-sided 95% ~ 1.96/sqrt(n)); 0 if none.
+    """
+    name = "pac_ret_lag1_5"
+    description = "First significant PACF lag (1..5) for log returns; 0 if none. Significance ~ 1.96/sqrt(n)."
+    required_full_columns = ("symbol","time","close")
+    required_pv_columns = ("symbol",)
+    maxlag = 5
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx,date,list(self.required_full_columns))
+        sample = self.load_pv(ctx,date,list(self.required_pv_columns))
+        if df is None or sample is None: return None
+        out = sample[["symbol"]].copy()
+        if df.empty or sample.empty: out["value"]=pd.NA; return out
+        df = self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59")
+        df = df[df.symbol.isin(set(sample.symbol.unique()))]
+        if df.empty: out["value"]=pd.NA; return out
+        df = df.copy(); df["close"]=pd.to_numeric(df["close"],errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty: out["value"]=pd.NA; return out
+
+        m = int(self.maxlag); res={}
+        for sym,g in df.groupby("symbol",sort=False):
+            r = np.log(g.sort_index()["close"]).diff().replace([np.inf,-np.inf],np.nan).dropna().to_numpy()
+            n = r.size
+            if n < m + 2: res[sym]=np.nan; continue
+            rho = _acf(r, m)  # rho[0..m]
+            if not np.isfinite(rho).all(): rho = np.nan_to_num(rho, nan=0.0)
+            rho[0] = 1.0
+            pacf = _pacf_durbin_levinson(rho, m)  # pacf[0..m], use 1..m
+            thr = 1.96 / np.sqrt(n)
+            k0 = 0
+            for k in range(1, m+1):
+                if np.isfinite(pacf[k]) and abs(pacf[k]) > thr:
+                    k0 = k; break
+            res[sym] = float(k0)
+        out["value"] = out["symbol"].map(res); return out
+
+feature = PACRetLag1to5Feature()

--- a/cube2mat/features/path_efficiency.py
+++ b/cube2mat/features/path_efficiency.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class PathEfficiencyFeature(BaseFeature):
+    """
+    Path efficiency in [0,1]:
+      |last_close - first_open| / sum(|Δclose|)
+    Uses first available open within RTH as anchor; NaN if <2 closes or denom<=0.
+    """
+    name = "path_efficiency"
+    description = "Path straightness: |last_close - first_open| / sum|Δclose| in RTH."
+    required_full_columns = ("symbol","time","open","close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df=self.load_full(ctx,date,list(self.required_full_columns))
+        sample=self.load_pv(ctx,date,list(self.required_pv_columns))
+        if df is None or sample is None:return None
+        out=sample[["symbol"]].copy()
+        if df.empty or sample.empty: out["value"]=pd.NA; return out
+
+        df=self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59")
+        df=df[df.symbol.isin(set(sample.symbol.unique()))].copy()
+        for c in ("open","close"): df[c]=pd.to_numeric(df[c],errors="coerce")
+        df=df.dropna(subset=["close"])
+        if df.empty: out["value"]=pd.NA; return out
+
+        res={}
+        for sym,g in df.groupby("symbol",sort=False):
+            g=g.sort_index()
+            closes=g["close"].dropna()
+            if len(closes)<2: res[sym]=np.nan; continue
+            first_open = g["open"].dropna()
+            if first_open.empty: res[sym]=np.nan; continue
+            anchor = float(first_open.iloc[0])
+            lastc = float(closes.iloc[-1])
+            denom = float(np.abs(closes.diff().dropna()).sum())
+            if not np.isfinite(denom) or denom<=0:
+                res[sym]=np.nan; continue
+            val = abs(lastc - anchor) / denom
+            res[sym] = float(np.clip(val, 0.0, 1.0))
+        out["value"]=out["symbol"].map(res); return out
+
+feature = PathEfficiencyFeature()

--- a/cube2mat/features/spectral_entropy_close.py
+++ b/cube2mat/features/spectral_entropy_close.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class SpectralEntropyCloseFeature(BaseFeature):
+    """
+    Normalized spectral entropy of de-trended close via FFT:
+      - build power spectrum excluding DC; p_i = P_i / sum P
+      - H = -sum p_i log(p_i) / log(m) in [0,1]; NaN if m<2 or invalid.
+    """
+    name = "spectral_entropy_close"
+    description = "Normalized spectral entropy (0..1) of detrended close."
+    required_full_columns = ("symbol","time","close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df=self.load_full(ctx,date,["symbol","time","close"])
+        sample=self.load_pv(ctx,date,["symbol"])
+        if df is None or sample is None:return None
+        out=sample[["symbol"]].copy()
+        if df.empty or sample.empty: out["value"]=pd.NA; return out
+
+        df=self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59")
+        df=df[df.symbol.isin(set(sample.symbol.unique()))]
+        if df.empty: out["value"]=pd.NA; return out
+        df["close"]=pd.to_numeric(df["close"],errors="coerce"); df=df.dropna(subset=["close"])
+        if df.empty: out["value"]=pd.NA; return out
+
+        res={}
+        for sym,g in df.groupby("symbol",sort=False):
+            y=g.sort_index()["close"].to_numpy(dtype=float)
+            n=y.size
+            if n<8: res[sym]=np.nan; continue
+            t=np.linspace(0.0,1.0,n,endpoint=True)
+            X=np.column_stack([np.ones(n), t])
+            beta,_=np.linalg.lstsq(X,y,rcond=None)
+            e=y - X@beta
+            e=e - e.mean()
+            powr = (np.fft.rfft(e) * np.fft.rfft(e).conj()).real
+            pos = powr[1:]
+            m = pos.size
+            tot = float(np.sum(pos))
+            if m < 2 or tot <= 0 or not np.isfinite(tot):
+                res[sym]=np.nan; continue
+            p = pos / tot
+            p = p[p > 0]
+            if p.size < 2:
+                res[sym]=np.nan; continue
+            H = float(-np.sum(p * np.log(p)) / np.log(m))
+            res[sym]=float(np.clip(H, 0.0, 1.0))
+        out["value"]=out["symbol"].map(res); return out
+
+feature = SpectralEntropyCloseFeature()

--- a/cube2mat/features/spectral_lowfreq_share_close.py
+++ b/cube2mat/features/spectral_lowfreq_share_close.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class SpectralLowfreqShareCloseFeature(BaseFeature):
+    """
+    Low-frequency energy share of de-trended close via FFT:
+      - y = close (RTH), de-trend by OLS on time + remove mean
+      - P = |rfft(y)|^2; exclude DC bin
+      - take first p% of positive frequencies (default p=10%), share = sum(low)/sum(all)
+    """
+    name = "spectral_lowfreq_share_close"
+    description = "Share of low-frequency FFT energy of detrended close (p=10%)."
+    required_full_columns = ("symbol","time","close")
+    required_pv_columns = ("symbol",)
+    p = 0.10
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df=self.load_full(ctx,date,["symbol","time","close"])
+        sample=self.load_pv(ctx,date,["symbol"])
+        if df is None or sample is None:return None
+        out=sample[["symbol"]].copy()
+        if df.empty or sample.empty: out["value"]=pd.NA; return out
+
+        df=self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59")
+        df=df[df.symbol.isin(set(sample.symbol.unique()))]
+        if df.empty: out["value"]=pd.NA; return out
+        df["close"]=pd.to_numeric(df["close"],errors="coerce"); df=df.dropna(subset=["close"])
+        if df.empty: out["value"]=pd.NA; return out
+
+        p=float(self.p); res={}
+        for sym,g in df.groupby("symbol",sort=False):
+            y=g.sort_index()["close"].to_numpy(dtype=float)
+            n=y.size
+            if n<8: res[sym]=np.nan; continue
+            t=np.linspace(0.0,1.0,n,endpoint=True)
+            X=np.column_stack([np.ones(n), t])
+            beta,_ = np.linalg.lstsq(X,y,rcond=None)
+            e=y - X@beta
+            e=e - e.mean()
+            spec=np.fft.rfft(e)
+            powr = (spec*spec.conj()).real
+            if powr.size <= 1:
+                res[sym]=np.nan; continue
+            pos = powr[1:]
+            tot = float(np.sum(pos))
+            if tot <= 0 or not np.isfinite(tot): res[sym]=np.nan; continue
+            m = pos.size
+            k = max(1, int(np.floor(p * m)))
+            val = float(np.sum(pos[:k]) / tot)
+            res[sym]=val
+        out["value"]=out["symbol"].map(res); return out
+
+feature = SpectralLowfreqShareCloseFeature()

--- a/cube2mat/features/transition_asymmetry.py
+++ b/cube2mat/features/transition_asymmetry.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class TransitionAsymmetryFeature(BaseFeature):
+    """
+    Asymmetry of sign transitions using simple returns in RTH:
+      value = P(up->up) - P(down->down)
+    where P(up->up) computed among pairs with previous sign=+1 (exclude zeros), etc.
+    """
+    name = "transition_asymmetry"
+    description = "P(up→up) - P(down→down) from simple-return signs (exclude zeros)."
+    required_full_columns = ("symbol","time","close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df=self.load_full(ctx,date,["symbol","time","close"])
+        sample=self.load_pv(ctx,date,["symbol"])
+        if df is None or sample is None:return None
+        out=sample[["symbol"]].copy()
+        if df.empty or sample.empty: out["value"]=pd.NA; return out
+
+        df=self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59")
+        df=df[df.symbol.isin(set(sample.symbol.unique()))].copy()
+        df["close"]=pd.to_numeric(df["close"],errors="coerce")
+        df=df.dropna(subset=["close"])
+        if df.empty: out["value"]=pd.NA; return out
+
+        res={}
+        for sym,g in df.groupby("symbol",sort=False):
+            s = g.sort_index()["close"].pct_change().to_numpy()
+            a = np.sign(s[:-1]); b = np.sign(s[1:])
+            # up->?
+            m_up = (a==1)
+            p_uu = np.nan
+            if m_up.sum()>0:
+                p_uu = float((b[m_up]==1).mean())
+            # down->?
+            m_dn = (a==-1)
+            p_dd = np.nan
+            if m_dn.sum()>0:
+                p_dd = float((b[m_dn]==-1).mean())
+            val = np.nan
+            if np.isfinite(p_uu) and np.isfinite(p_dd):
+                val = p_uu - p_dd
+            res[sym] = val
+        out["value"]=out["symbol"].map(res); return out
+
+feature = TransitionAsymmetryFeature()

--- a/cube2mat/features/transition_p_same_sign.py
+++ b/cube2mat/features/transition_p_same_sign.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class TransitionPSameSignFeature(BaseFeature):
+    """
+    P(sign_t == sign_{t-1}) using simple returns in RTH, excluding zeros.
+    """
+    name = "transition_p_same_sign"
+    description = "Probability that consecutive simple returns have the same sign (exclude zeros)."
+    required_full_columns = ("symbol","time","close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df=self.load_full(ctx,date,list(self.required_full_columns))
+        sample=self.load_pv(ctx,date,list(self.required_pv_columns))
+        if df is None or sample is None:return None
+        out=sample[["symbol"]].copy()
+        if df.empty or sample.empty: out["value"]=pd.NA; return out
+
+        df=self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59")
+        df=df[df.symbol.isin(set(sample.symbol.unique()))].copy()
+        df["close"]=pd.to_numeric(df["close"],errors="coerce")
+        df=df.dropna(subset=["close"])
+        if df.empty: out["value"]=pd.NA; return out
+
+        res={}
+        for sym,g in df.groupby("symbol",sort=False):
+            s = g.sort_index()["close"].pct_change().to_numpy()
+            sgn = np.sign(s)
+            # valid pairs where both signs are nonzero
+            a = sgn[:-1]; b = sgn[1:]
+            mask = (a!=0) & (b!=0)
+            if mask.sum() < 1: res[sym]=np.nan; continue
+            match = (a[mask] == b[mask]).mean()
+            res[sym] = float(match)
+        out["value"]=out["symbol"].map(res); return out
+
+feature = TransitionPSameSignFeature()

--- a/cube2mat/features/turning_point_count.py
+++ b/cube2mat/features/turning_point_count.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class TurningPointCountFeature(BaseFeature):
+    """
+    Count of turning points using sign changes of close differences, with small-move filtering:
+      - d = diff(close)
+      - threshold = theta * median(|d|), theta=0.1 (if median==0 -> 0)
+      - keep |d| > threshold, remove zeros, count sign flips
+    """
+    name = "turning_point_count"
+    description = "Number of local extrema based on filtered sign flips of Δclose (theta=0.1)."
+    required_full_columns = ("symbol","time","close")
+    required_pv_columns = ("symbol",)
+    theta = 0.1
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df=self.load_full(ctx,date,["symbol","time","close"])
+        sample=self.load_pv(ctx,date,["symbol"])
+        if df is None or sample is None:return None
+        out=sample[["symbol"]].copy()
+        if df.empty or sample.empty: out["value"]=pd.NA; return out
+
+        df=self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59")
+        df=df[df.symbol.isin(set(sample.symbol.unique()))].copy()
+        df["close"]=pd.to_numeric(df["close"],errors="coerce")
+        df=df.dropna(subset=["close"])
+        if df.empty: out["value"]=pd.NA; return out
+
+        th=float(self.theta); res={}
+        for sym,g in df.groupby("symbol",sort=False):
+            s=g.sort_index()["close"].to_numpy(dtype=float)
+            if s.size<3: res[sym]=np.nan; continue
+            d = np.diff(s)
+            med = np.median(np.abs(d))
+            thr = th * med
+            if not np.isfinite(thr): thr = 0.0
+            keep = np.abs(d) > thr
+            d2 = d[keep]
+            if d2.size < 2:
+                res[sym] = np.nan; continue
+            sign = np.sign(d2)
+            sign = sign[sign != 0]
+            if sign.size < 2:
+                res[sym] = np.nan; continue
+            flips = int(np.sum(sign[1:] != sign[:-1]))
+            res[sym] = float(flips)
+        out["value"]=out["symbol"].map(res); return out
+
+feature = TurningPointCountFeature()

--- a/cube2mat/features/upper_shadow_ratio_mean.py
+++ b/cube2mat/features/upper_shadow_ratio_mean.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class UpperShadowRatioMeanFeature(BaseFeature):
+    """
+    Mean upper shadow ratio: (high - max(open,close)) / (high - low), exclude zero-range bars.
+    """
+    name = "upper_shadow_ratio_mean"
+    description = "Mean upper shadow / range ratio in RTH; exclude zero-range bars."
+    required_full_columns = ("symbol","time","open","high","low","close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df=self.load_full(ctx,date,list(self.required_full_columns))
+        sample=self.load_pv(ctx,date,list(self.required_pv_columns))
+        if df is None or sample is None:return None
+        out=sample[["symbol"]].copy()
+        if df.empty or sample.empty: out["value"]=pd.NA; return out
+        df=self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59")
+        df=df[df.symbol.isin(set(sample.symbol.unique()))]
+        if df.empty: out["value"]=pd.NA; return out
+        for c in ("open","high","low","close"): df[c]=pd.to_numeric(df[c],errors="coerce")
+        df=df.dropna(subset=["open","high","low","close"])
+        if df.empty: out["value"]=pd.NA; return out
+
+        rng=(df["high"]-df["low"])
+        up=(df["high"]-np.maximum(df["open"],df["close"])).clip(lower=0)
+        df2=df.assign(rng=rng, up=up)
+        df2=df2[df2["rng"]>0]
+        res=df2.groupby("symbol").apply(lambda g: float((g["up"]/g["rng"]).mean()) if len(g)>0 else np.nan)
+        out["value"]=out["symbol"].map(res); return out
+
+feature = UpperShadowRatioMeanFeature()

--- a/cube2mat/features/xcorr_volume_absret_lag1.py
+++ b/cube2mat/features/xcorr_volume_absret_lag1.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class XCorrVolumeAbsRetLag1Feature(BaseFeature):
+    """
+    Pearson correlation between volume_t and |logret_{t+1}| within 09:30–15:59.
+    NaN if <3 pairs or zero variance.
+    """
+    name = "xcorr_volume_absret_lag1"
+    description = "Corr(volume_t, |logret_{t+1}|) in RTH; lead-lag (volume leads)."
+    required_full_columns = ("symbol","time","close","volume")
+    required_pv_columns = ("symbol",)
+
+    @staticmethod
+    def _corr(x: np.ndarray, y: np.ndarray) -> float:
+        x = np.asarray(x, dtype=float); y = np.asarray(y, dtype=float)
+        if x.size != y.size or x.size < 3:
+            return np.nan
+        xc = x - x.mean(); yc = y - y.mean()
+        sx = float(np.sqrt(np.sum(xc*xc))); sy = float(np.sqrt(np.sum(yc*yc)))
+        if sx <= 0 or sy <= 0 or not np.isfinite(sx*sy): return np.nan
+        return float(np.sum(xc*yc) / (sx*sy))
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx,date,list(self.required_full_columns))
+        sample = self.load_pv(ctx,date,list(self.required_pv_columns))
+        if df is None or sample is None: return None
+        out = sample[["symbol"]].copy()
+        if df.empty or sample.empty: out["value"]=pd.NA; return out
+
+        df = self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59")
+        df = df[df.symbol.isin(set(sample.symbol.unique()))].copy()
+        for c in ("close","volume"): df[c]=pd.to_numeric(df[c],errors="coerce")
+        df = df.dropna(subset=["close","volume"])
+        if df.empty: out["value"]=pd.NA; return out
+
+        res={}
+        for sym,g in df.groupby("symbol",sort=False):
+            g=g.sort_index()
+            r = np.log(g["close"]).diff().replace([np.inf,-np.inf],np.nan).abs()
+            v = g["volume"]
+            y = r.shift(-1)  # |ret_{t+1}|
+            xy = pd.concat([v, y], axis=1).dropna()
+            res[sym] = self._corr(xy.iloc[:,0].to_numpy(), xy.iloc[:,1].to_numpy())
+        out["value"]=out["symbol"].map(res); return out
+
+feature = XCorrVolumeAbsRetLag1Feature()


### PR DESCRIPTION
## Summary
- add intraday return dependency features (autocorrelation, PACF, Ljung–Box, volume/return cross-correlations, sign transitions)
- add candlestick morphology metrics for bodies, shadows, doji, and marubozu patterns
- add path efficiency and complexity indicators including turning points, spectral measures, and Hurst exponent

## Testing
- `python -m py_compile cube2mat/features/ac_ret_lag2.py cube2mat/features/ac_ret_lag5.py cube2mat/features/pac_ret_lag1_5.py cube2mat/features/ljung_box_q_5.py cube2mat/features/xcorr_volume_absret_lag1.py cube2mat/features/transition_p_same_sign.py cube2mat/features/transition_asymmetry.py cube2mat/features/mean_body_to_range.py cube2mat/features/upper_shadow_ratio_mean.py cube2mat/features/lower_shadow_ratio_mean.py cube2mat/features/doji_density.py cube2mat/features/marubozu_density.py cube2mat/features/path_efficiency.py cube2mat/features/turning_point_count.py cube2mat/features/spectral_lowfreq_share_close.py cube2mat/features/spectral_entropy_close.py cube2mat/features/hurst_rs_ret.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68a1edac8044832ab3e1dab043fa8552