### PR TITLE
Add risk and session linkage features

### DIFF
--- a/cube2mat/features/close_to_open_ret.py
+++ b/cube2mat/features/close_to_open_ret.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class CloseToOpenRetFeature(BaseFeature):
+    """
+    Session close-to-open simple return (reverse anchor within same RTH):
+      value = first_open / last_close - 1; NaN if missing or last_close<=0.
+    """
+    name = "close_to_open_ret"
+    description = "Simple return from last close back to first open within same RTH."
+    required_full_columns = ("symbol","time","open","close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df=self.load_full(ctx,date,["symbol","time","open","close"])
+        sample=self.load_pv(ctx,date,["symbol"])
+        if df is None or sample is None: return None
+        out=sample[["symbol"]].copy()
+
+        if df.empty or sample.empty: out["value"]=pd.NA; return out
+        df=self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59").copy()
+        for c in ("open","close"): df[c]=pd.to_numeric(df[c],errors="coerce")
+        df=df.dropna(subset=["open","close"])
+        df=df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty: out["value"]=pd.NA; return out
+
+        res={}
+        for sym,g in df.groupby("symbol",sort=False):
+            g=g.sort_index()
+            o=g["open"].dropna()
+            c=g["close"].dropna()
+            if o.empty or c.empty: res[sym]=np.nan; continue
+            o0=float(o.iloc[0]); cL=float(c.iloc[-1])
+            if cL<=0: res[sym]=np.nan; continue
+            res[sym]= o0/cL - 1.0
+        out["value"]=out["symbol"].map(res); return out
+
+
+feature = CloseToOpenRetFeature()

--- a/cube2mat/features/clv_session.py
+++ b/cube2mat/features/clv_session.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class CLVSessionFeature(BaseFeature):
+    """
+    Close Location Value over session range:
+      CLV = ((last_close - L) - (H - last_close)) / (H - L), H=max(high), L=min(low)
+    NaN if (H-L)<=0 or no bars.
+    """
+    name = "clv_session"
+    description = "Session Close Location Value in RTH using session H/L and last close."
+    required_full_columns = ("symbol","time","high","low","close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df=self.load_full(ctx,date,["symbol","time","high","low","close"])
+        sample=self.load_pv(ctx,date,["symbol"])
+        if df is None or sample is None: return None
+        out=sample[["symbol"]].copy()
+
+        if df.empty or sample.empty:
+            out["value"]=pd.NA; return out
+
+        df=self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59").copy()
+        for c in ("high","low","close"): df[c]=pd.to_numeric(df[c],errors="coerce")
+        df=df.dropna(subset=["high","low","close"])
+        df=df[df["symbol"].isin(sample["symbol"].unique())]
+
+        if df.empty: out["value"]=pd.NA; return out
+        res={}
+        for sym,g in df.groupby("symbol",sort=False):
+            g=g.sort_index()
+            H=float(g["high"].max()); L=float(g["low"].min())
+            if not np.isfinite(H) or not np.isfinite(L) or (H-L)<=0 or len(g)<1:
+                res[sym]=np.nan; continue
+            c=float(g["close"].iloc[-1])
+            res[sym]= ((c - L) - (H - c)) / (H - L)
+        out["value"]=out["symbol"].map(res); return out
+
+
+feature = CLVSessionFeature()

--- a/cube2mat/features/cv_n.py
+++ b/cube2mat/features/cv_n.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class CVNFeature(BaseFeature):
+    """
+    Coefficient of variation of per-bar trade count n in RTH: std(n)/mean(n).
+    NaN if <3 bars or mean<=0.
+    """
+    name = "cv_n"
+    description = "Std/mean of trade count n across RTH bars."
+    required_full_columns = ("symbol","time","n")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df=self.load_full(ctx,date,["symbol","time","n"])
+        sample=self.load_pv(ctx,date,["symbol"])
+        if df is None or sample is None:return None
+        out=sample[["symbol"]].copy()
+
+        if df.empty or sample.empty:
+            out["value"]=pd.NA; return out
+
+        df=self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59")
+        df=df[df["symbol"].isin(sample["symbol"].unique())].copy()
+        df["n"]=pd.to_numeric(df["n"],errors="coerce")
+        df=df.dropna(subset=["n"])
+
+        if df.empty: out["value"]=pd.NA; return out
+        res={}
+        for sym,g in df.groupby("symbol",sort=False):
+            n=g.sort_index()["n"].dropna()
+            if len(n)<3: res[sym]=np.nan; continue
+            mu=float(n.mean()); sd=float(n.std(ddof=1))
+            res[sym]=sd/mu if (np.isfinite(mu) and mu>0) else np.nan
+        out["value"]=out["symbol"].map(res); return out
+
+
+feature = CVNFeature()

--- a/cube2mat/features/cv_volume.py
+++ b/cube2mat/features/cv_volume.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class CVVolumeFeature(BaseFeature):
+    """
+    Coefficient of variation of per-bar volume in RTH: std(volume)/mean(volume).
+    NaN if <3 bars or mean<=0.
+    """
+    name = "cv_volume"
+    description = "Std/mean of volume across RTH bars."
+    required_full_columns = ("symbol","time","volume")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df=self.load_full(ctx,date,["symbol","time","volume"])
+        sample=self.load_pv(ctx,date,["symbol"])
+        if df is None or sample is None:return None
+        out=sample[["symbol"]].copy()
+
+        if df.empty or sample.empty:
+            out["value"]=pd.NA; return out
+
+        df=self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59")
+        df=df[df["symbol"].isin(sample["symbol"].unique())].copy()
+        df["volume"]=pd.to_numeric(df["volume"],errors="coerce")
+        df=df.dropna(subset=["volume"])
+
+        if df.empty: out["value"]=pd.NA; return out
+        res={}
+        for sym,g in df.groupby("symbol",sort=False):
+            v=g.sort_index()["volume"].dropna()
+            if len(v)<3: res[sym]=np.nan; continue
+            mu=float(v.mean()); sd=float(v.std(ddof=1))
+            res[sym]=sd/mu if (np.isfinite(mu) and mu>0) else np.nan
+        out["value"]=out["symbol"].map(res); return out
+
+
+feature = CVVolumeFeature()

--- a/cube2mat/features/mean_over_median_absret.py
+++ b/cube2mat/features/mean_over_median_absret.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class MeanOverMedianAbsRetFeature(BaseFeature):
+    """
+    Ratio mean(|logret|)/median(|logret|) within 09:30–15:59.
+    NaN if <3 returns or median==0.
+    """
+    name = "mean_over_median_absret"
+    description = "mean(|logret|)/median(|logret|) as tail-sensitivity proxy (RTH)."
+    required_full_columns = ("symbol","time","close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df=self.load_full(ctx,date,["symbol","time","close"])
+        sample=self.load_pv(ctx,date,["symbol"])
+        if df is None or sample is None: return None
+        out=sample[["symbol"]].copy()
+
+        if df.empty or sample.empty:
+            out["value"]=pd.NA; return out
+
+        df=self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59")
+        df=df[df["symbol"].isin(sample["symbol"].unique())].copy()
+        df["close"]=pd.to_numeric(df["close"],errors="coerce")
+        df=df.dropna(subset=["close"])
+
+        if df.empty: out["value"]=pd.NA; return out
+        res={}
+        for sym,g in df.groupby("symbol",sort=False):
+            a=np.log(g.sort_index()["close"]).diff().replace([np.inf,-np.inf],np.nan).abs().dropna()
+            if len(a)<3: res[sym]=np.nan; continue
+            med=float(a.median())
+            mu=float(a.mean())
+            res[sym]=mu/med if (np.isfinite(med) and med>0) else np.nan
+        out["value"]=out["symbol"].map(res); return out
+
+
+feature = MeanOverMedianAbsRetFeature()

--- a/cube2mat/features/open_to_close_ret.py
+++ b/cube2mat/features/open_to_close_ret.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class OpenToCloseRetFeature(BaseFeature):
+    """
+    Session open-to-close simple return in RTH:
+      value = last_close / first_open - 1; NaN if missing or nonpositive anchors.
+    """
+    name = "open_to_close_ret"
+    description = "Simple return from first open to last close within RTH."
+    required_full_columns = ("symbol","time","open","close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df=self.load_full(ctx,date,["symbol","time","open","close"])
+        sample=self.load_pv(ctx,date,["symbol"])
+        if df is None or sample is None: return None
+        out=sample[["symbol"]].copy()
+
+        if df.empty or sample.empty: out["value"]=pd.NA; return out
+        df=self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59").copy()
+        for c in ("open","close"): df[c]=pd.to_numeric(df[c],errors="coerce")
+        df=df.dropna(subset=["open","close"])
+        df=df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty: out["value"]=pd.NA; return out
+
+        res={}
+        for sym,g in df.groupby("symbol",sort=False):
+            g=g.sort_index()
+            o=g["open"].dropna()
+            c=g["close"].dropna()
+            if o.empty or c.empty: res[sym]=np.nan; continue
+            o0=float(o.iloc[0]); cL=float(c.iloc[-1])
+            if o0<=0: res[sym]=np.nan; continue
+            res[sym]= cL/o0 - 1.0
+        out["value"]=out["symbol"].map(res); return out
+
+
+feature = OpenToCloseRetFeature()

--- a/cube2mat/features/post_vol_ratio_to_rth.py
+++ b/cube2mat/features/post_vol_ratio_to_rth.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class PostVolRatioToRTHFeature(BaseFeature):
+    """
+    Ratio of post-market total volume to RTH total volume:
+      Post: 16:00–23:59; RTH: 09:30–15:59.
+    NaN if RTH volume<=0.
+    """
+    name = "post_vol_ratio_to_rth"
+    description = "Post-market volume / RTH volume ratio for the day."
+    required_full_columns = ("symbol","time","volume")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df=self.load_full(ctx,date,["symbol","time","volume"])
+        sample=self.load_pv(ctx,date,["symbol"])
+        if df is None or sample is None:return None
+        out=sample[["symbol"]].copy()
+
+        if df.empty or sample.empty:
+            out["value"]=pd.NA; return out
+
+        df=self.ensure_et_index(df,"time",ctx.tz)
+        df=df[df["symbol"].isin(sample["symbol"].unique())].copy()
+        df["volume"]=pd.to_numeric(df["volume"],errors="coerce"); df=df.dropna(subset=["volume"])
+        if df.empty: out["value"]=pd.NA; return out
+
+        res={}
+        post=df.between_time("16:00","23:59")
+        rth =df.between_time("09:30","15:59")
+        for sym in sample["symbol"].unique():
+            v_post=float(post[post["symbol"]==sym]["volume"].sum())
+            v_rth =float(rth [rth ["symbol"]==sym]["volume"].sum())
+            res[sym]= (v_post/v_rth) if (np.isfinite(v_rth) and v_rth>0) else np.nan
+        out["value"]=out["symbol"].map(res); return out
+
+
+feature = PostVolRatioToRTHFeature()

--- a/cube2mat/features/premkt_to_rth_ret_corr.py
+++ b/cube2mat/features/premkt_to_rth_ret_corr.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class PremktToRTHRetCorrFeature(BaseFeature):
+    """
+    Approximate linkage between pre-market and RTH returns (single-day proxy):
+      value = sign(sum_pre_logret) * sign(sum_rth_logret)
+    in {-1, 0, +1}; NaN if either segment lacks >=1 return.
+      Pre: 00:00–09:29; RTH: 09:30–15:59.
+    """
+    name = "premkt_to_rth_ret_corr"
+    description = "Sign consistency proxy between pre-market and RTH total log returns."
+    required_full_columns = ("symbol","time","close")
+    required_pv_columns = ("symbol",)
+
+    @staticmethod
+    def _seg(df: pd.DataFrame, start: str, end: str) -> pd.Series:
+        seg = df.between_time(start, end)["close"]
+        r = np.log(seg).diff().replace([np.inf,-np.inf],np.nan).dropna()
+        return r
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df=self.load_full(ctx,date,["symbol","time","close"])
+        sample=self.load_pv(ctx,date,["symbol"])
+        if df is None or sample is None:return None
+        out=sample[["symbol"]].copy()
+
+        if df.empty or sample.empty:
+            out["value"]=pd.NA; return out
+
+        df=self.ensure_et_index(df,"time",ctx.tz)
+        df=df[df["symbol"].isin(sample["symbol"].unique())].copy()
+        df["close"]=pd.to_numeric(df["close"],errors="coerce"); df=df.dropna(subset=["close"])
+        if df.empty: out["value"]=pd.NA; return out
+
+        res={}
+        for sym,g in df.groupby("symbol",sort=False):
+            g=g.sort_index()
+            pre = self._seg(g, "00:00", "09:29")
+            rth = self._seg(g, "09:30", "15:59")
+            if len(pre)<1 or len(rth)<1:
+                res[sym]=np.nan; continue
+            s = np.sign(pre.sum()) * np.sign(rth.sum())
+            res[sym] = float(s)
+        out["value"]=out["symbol"].map(res); return out
+
+
+feature = PremktToRTHRetCorrFeature()

--- a/cube2mat/features/premkt_vol_ratio_to_rth.py
+++ b/cube2mat/features/premkt_vol_ratio_to_rth.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class PremktVolRatioToRTHFeature(BaseFeature):
+    """
+    Ratio of pre-market total volume to RTH total volume:
+      Pre: 00:00–09:29; RTH: 09:30–15:59.
+    NaN if RTH volume<=0.
+    """
+    name = "premkt_vol_ratio_to_rth"
+    description = "Pre-market volume / RTH volume ratio for the day."
+    required_full_columns = ("symbol","time","volume")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df=self.load_full(ctx,date,["symbol","time","volume"])
+        sample=self.load_pv(ctx,date,["symbol"])
+        if df is None or sample is None:return None
+        out=sample[["symbol"]].copy()
+
+        if df.empty or sample.empty:
+            out["value"]=pd.NA; return out
+
+        df=self.ensure_et_index(df,"time",ctx.tz)
+        df=df[df["symbol"].isin(sample["symbol"].unique())].copy()
+        df["volume"]=pd.to_numeric(df["volume"],errors="coerce"); df=df.dropna(subset=["volume"])
+        if df.empty: out["value"]=pd.NA; return out
+
+        res={}
+        pre=df.between_time("00:00","09:29")
+        rth=df.between_time("09:30","15:59")
+        for sym in sample["symbol"].unique():
+            v_pre=float(pre[pre["symbol"]==sym]["volume"].sum())
+            v_rth=float(rth[rth["symbol"]==sym]["volume"].sum())
+            res[sym]= (v_pre/v_rth) if (np.isfinite(v_rth) and v_rth>0) else np.nan
+        out["value"]=out["symbol"].map(res); return out
+
+
+feature = PremktVolRatioToRTHFeature()

--- a/cube2mat/features/ret_es_q05.py
+++ b/cube2mat/features/ret_es_q05.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class RetESQ05Feature(BaseFeature):
+    """
+    5% Expected Shortfall (ES) of intraday log returns within 09:30–15:59.
+      r = diff(log(close)); q = quantile(r,0.05); ES = mean(r[r<=q])
+    NaN if <3 returns or tail empty.
+    """
+    name = "ret_es_q05"
+    description = "5% ES (expected shortfall) of intraday log returns (RTH)."
+    required_full_columns = ("symbol","time","close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df=self.load_full(ctx,date,["symbol","time","close"])
+        sample=self.load_pv(ctx,date,["symbol"])
+        if df is None or sample is None: return None
+        out=sample[["symbol"]].copy()
+
+        if df.empty or sample.empty:
+            out["value"]=pd.NA; return out
+
+        df=self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59")
+        df=df[df["symbol"].isin(sample["symbol"].unique())].copy()
+        df["close"]=pd.to_numeric(df["close"],errors="coerce")
+        df=df.dropna(subset=["close"])
+        if df.empty: out["value"]=pd.NA; return out
+
+        res={}
+        for sym,g in df.groupby("symbol",sort=False):
+            r=np.log(g.sort_index()["close"]).diff().replace([np.inf,-np.inf],np.nan).dropna()
+            if len(r)<3: res[sym]=np.nan; continue
+            q=float(r.quantile(0.05))
+            tail=r[r<=q]
+            res[sym]=float(tail.mean()) if len(tail)>0 else np.nan
+        out["value"]=out["symbol"].map(res); return out
+
+
+feature = RetESQ05Feature()

--- a/cube2mat/features/ret_var_q05.py
+++ b/cube2mat/features/ret_var_q05.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class RetVaRQ05Feature(BaseFeature):
+    """
+    5% VaR of intraday log returns within 09:30–15:59.
+    r = diff(log(close)); VaR_5 = quantile(r, 0.05). NaN if <3 returns.
+    """
+    name = "ret_var_q05"
+    description = "5% quantile VaR of intraday log returns (RTH)."
+    required_full_columns = ("symbol","time","close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df=self.load_full(ctx,date,["symbol","time","close"])
+        sample=self.load_pv(ctx,date,["symbol"])
+        if df is None or sample is None: return None
+        out=sample[["symbol"]].copy()
+
+        if df.empty or sample.empty:
+            out["value"]=pd.NA; return out
+
+        df=self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59")
+        df=df[df["symbol"].isin(sample["symbol"].unique())].copy()
+        df["close"]=pd.to_numeric(df["close"],errors="coerce")
+        df=df.dropna(subset=["close"])
+        if df.empty: out["value"]=pd.NA; return out
+
+        res={}
+        for sym,g in df.groupby("symbol",sort=False):
+            r=np.log(g.sort_index()["close"]).diff().replace([np.inf,-np.inf],np.nan).dropna()
+            res[sym]=float(r.quantile(0.05)) if len(r)>=3 else np.nan
+        out["value"]=out["symbol"].map(res); return out
+
+
+feature = RetVaRQ05Feature()

--- a/cube2mat/features/trade_size_gini.py
+++ b/cube2mat/features/trade_size_gini.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+from volume_gini import _gini  # 复用
+
+
+class TradeSizeGiniFeature(BaseFeature):
+    """
+    Gini index of per-bar trade size (volume/n) distribution in RTH.
+    Use bars with n>0; NaN if <2 valid bars or sum(tsize)<=0.
+    """
+    name = "trade_size_gini"
+    description = "Gini of per-bar average trade size (volume/n) across RTH bars."
+    required_full_columns = ("symbol","time","volume","n")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df=self.load_full(ctx,date,["symbol","time","volume","n"])
+        sample=self.load_pv(ctx,date,["symbol"])
+        if df is None or sample is None:return None
+        out=sample[["symbol"]].copy()
+
+        if df.empty or sample.empty:
+            out["value"]=pd.NA; return out
+
+        df=self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59")
+        df=df[df["symbol"].isin(sample["symbol"].unique())].copy()
+        df["volume"]=pd.to_numeric(df["volume"],errors="coerce")
+        df["n"]=pd.to_numeric(df["n"],errors="coerce")
+        df=df.dropna(subset=["volume","n"])
+        df=df[df["n"]>0]
+
+        if df.empty: out["value"]=pd.NA; return out
+        res = df.assign(tsize=df["volume"]/df["n"]).groupby("symbol")["tsize"].apply(lambda s: _gini(s.values))
+        out["value"]=out["symbol"].map(res); return out
+
+
+feature = TradeSizeGiniFeature()

--- a/cube2mat/features/volume_entropy.py
+++ b/cube2mat/features/volume_entropy.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class VolumeEntropyFeature(BaseFeature):
+    """
+    Normalized Shannon entropy H/Hmax of volume distribution across RTH bars, in [0,1].
+    p_i = v_i/sum(v); H = -sum p_i log p_i; Hmax=log(m). NaN if sum<=0 or m<2.
+    """
+    name = "volume_entropy"
+    description = "Normalized entropy of per-bar volume distribution (RTH)."
+    required_full_columns = ("symbol","time","volume")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df=self.load_full(ctx,date,["symbol","time","volume"])
+        sample=self.load_pv(ctx,date,["symbol"])
+        if df is None or sample is None:return None
+        out=sample[["symbol"]].copy()
+
+        if df.empty or sample.empty:
+            out["value"]=pd.NA; return out
+
+        df=self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59")
+        df=df[df["symbol"].isin(sample["symbol"].unique())].copy()
+        df["volume"]=pd.to_numeric(df["volume"],errors="coerce")
+        df=df.dropna(subset=["volume"])
+
+        if df.empty: out["value"]=pd.NA; return out
+        res={}
+        for sym,g in df.groupby("symbol",sort=False):
+            v = g.sort_index()["volume"].astype(float).values
+            s = float(np.nansum(v))
+            if not np.isfinite(s) or s<=0: res[sym]=np.nan; continue
+            p = v / s
+            p = p[p>0]
+            m = p.size
+            if m < 2: res[sym]=np.nan; continue
+            H = float(-(p*np.log(p)).sum())
+            val = H / np.log(m)
+            res[sym]=float(np.clip(val,0.0,1.0))
+        out["value"]=out["symbol"].map(res); return out
+
+
+feature = VolumeEntropyFeature()

--- a/cube2mat/features/volume_gini.py
+++ b/cube2mat/features/volume_gini.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _gini(x: np.ndarray) -> float:
+    x = np.asarray(x, dtype=float)
+    x = x[np.isfinite(x) & (x >= 0)]
+    n = x.size; s = x.sum()
+    if n < 2 or s <= 0: return np.nan
+    xs = np.sort(x)
+    i = np.arange(1, n+1)
+    g = 1.0 - 2.0 * np.sum((n - i + 0.5) * xs) / (n * s)
+    return float(np.clip(g, 0.0, 1.0))
+
+
+class VolumeGiniFeature(BaseFeature):
+    """
+    Gini index of volume distribution across RTH bars.
+    """
+    name = "volume_gini"
+    description = "Gini of per-bar volume distribution in RTH."
+    required_full_columns = ("symbol","time","volume")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df=self.load_full(ctx,date,["symbol","time","volume"])
+        sample=self.load_pv(ctx,date,["symbol"])
+        if df is None or sample is None:return None
+        out=sample[["symbol"]].copy()
+
+        if df.empty or sample.empty:
+            out["value"]=pd.NA; return out
+
+        df=self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59")
+        df=df[df["symbol"].isin(sample["symbol"].unique())].copy()
+        df["volume"]=pd.to_numeric(df["volume"],errors="coerce")
+        df=df.dropna(subset=["volume"])
+
+        if df.empty: out["value"]=pd.NA; return out
+        res = df.groupby("symbol")["volume"].apply(lambda s: _gini(s.values))
+        out["value"]=out["symbol"].map(res); return out
+
+
+feature = VolumeGiniFeature()

--- a/cube2mat/features/zero_ret_share.py
+++ b/cube2mat/features/zero_ret_share.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+import datetime as dt
+import numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class ZeroRetShareFeature(BaseFeature):
+    """
+    Share of bars with simple return close.pct_change()==0 (within epsilon).
+    epsilon default=1e-10; NaN if <1 return.
+    """
+    name = "zero_ret_share"
+    description = "Fraction of bars with near-zero simple returns (|ret|<=1e-10) in RTH."
+    required_full_columns = ("symbol","time","close")
+    required_pv_columns = ("symbol",)
+    eps = 1e-10
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df=self.load_full(ctx,date,["symbol","time","close"])
+        sample=self.load_pv(ctx,date,["symbol"])
+        if df is None or sample is None: return None
+        out=sample[["symbol"]].copy()
+
+        if df.empty or sample.empty:
+            out["value"]=pd.NA; return out
+
+        df=self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59")
+        df=df[df["symbol"].isin(sample["symbol"].unique())].copy()
+        df["close"]=pd.to_numeric(df["close"],errors="coerce")
+        df=df.dropna(subset=["close"])
+
+        if df.empty: out["value"]=pd.NA; return out
+        eps=float(self.eps)
+        res={}
+        for sym,g in df.groupby("symbol",sort=False):
+            r=g.sort_index()["close"].pct_change().replace([np.inf,-np.inf],np.nan).dropna()
+            if len(r)<1: res[sym]=np.nan; continue
+            res[sym]=float((r.abs()<=eps).mean())
+        out["value"]=out["symbol"].map(res); return out
+
+
+feature = ZeroRetShareFeature()


### PR DESCRIPTION
## Summary
- add features for tail risk metrics like log-return VaR and ES
- add stability metrics for volume and trade count and inequality indices
- expose open/close return relations and pre/post market linkage to RTH

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68a1f0eba0cc832aab96f0e35be7afef