### PR TITLE
Add intraday correlation, variance, entropy, and jump features

### DIFF
--- a/cube2mat/features/corr_close_vwap.py
+++ b/cube2mat/features/corr_close_vwap.py
@@ -1,0 +1,64 @@
+# features/corr_close_vwap.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class CorrCloseVWAPFeature(BaseFeature):
+    """
+    09:30–15:59 内，close 与 vwap 的 Pearson 相关。
+    样本 <3 或任一方差为 0 时 NaN。
+    """
+
+    name = "corr_close_vwap"
+    description = "Correlation of close and vwap within RTH."
+    required_full_columns = ("symbol", "time", "close", "vwap")
+    required_pv_columns = ("symbol",)
+
+    @staticmethod
+    def _corr(x: np.ndarray, y: np.ndarray) -> float:
+        x = np.asarray(x, float)
+        y = np.asarray(y, float)
+        n = min(x.size, y.size)
+        if n < 3:
+            return np.nan
+        xc = x - x.mean()
+        yc = y - y.mean()
+        sx = np.sqrt((xc * xc).sum())
+        sy = np.sqrt((yc * yc).sum())
+        if sx <= 0 or sy <= 0 or not np.isfinite(sx * sy):
+            return np.nan
+        return float((xc * yc).sum() / (sx * sy))
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.copy()
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df["vwap"] = pd.to_numeric(df["vwap"], errors="coerce")
+        df = df.dropna(subset=["close", "vwap"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        res = df.groupby("symbol").apply(lambda g: self._corr(g.sort_index()["close"].to_numpy(), g.sort_index()["vwap"].to_numpy()))
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = CorrCloseVWAPFeature()

--- a/cube2mat/features/corr_ret_volume.py
+++ b/cube2mat/features/corr_ret_volume.py
@@ -1,0 +1,70 @@
+# features/corr_ret_volume.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class CorrRetVolumeFeature(BaseFeature):
+    """
+    09:30–15:59 内，logret 与 volume 的 Pearson 相关。
+    成对样本 <3 或任一方差为 0 时 NaN。
+    """
+
+    name = "corr_ret_volume"
+    description = "Correlation of signed log returns and volume within RTH."
+    required_full_columns = ("symbol", "time", "close", "volume")
+    required_pv_columns = ("symbol",)
+
+    @staticmethod
+    def _corr(x: np.ndarray, y: np.ndarray) -> float:
+        x = np.asarray(x, float)
+        y = np.asarray(y, float)
+        n = min(x.size, y.size)
+        if n < 3:
+            return np.nan
+        xc = x - x.mean()
+        yc = y - y.mean()
+        sx = np.sqrt((xc * xc).sum())
+        sy = np.sqrt((yc * yc).sum())
+        if sx <= 0 or sy <= 0 or not np.isfinite(sx * sy):
+            return np.nan
+        return float((xc * yc).sum() / (sx * sy))
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.copy()
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df["volume"] = pd.to_numeric(df["volume"], errors="coerce")
+        df = df.dropna(subset=["close", "volume"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        res: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            g = g.sort_index()
+            r = np.log(g["close"]).diff().replace([np.inf, -np.inf], np.nan)
+            xy = pd.concat([r, g["volume"]], axis=1).dropna()
+            res[sym] = self._corr(xy.iloc[:, 0].to_numpy(), xy.iloc[:, 1].to_numpy())
+
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = CorrRetVolumeFeature()

--- a/cube2mat/features/early_late_vol_ratio_60m.py
+++ b/cube2mat/features/early_late_vol_ratio_60m.py
@@ -1,0 +1,60 @@
+# features/early_late_vol_ratio_60m.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class EarlyLateVolRatio60mFeature(BaseFeature):
+    """
+    前 60 分钟 vs 尾盘 60 分钟的收益波动比：
+      ratio = std(ret in 09:30–10:29) / std(ret in 15:00–15:59)。
+    任一段有效收益数 <2 或分母=0 → NaN。
+    """
+
+    name = "early_late_vol_ratio_60m"
+    description = "Std(ret)_first60 / Std(ret)_last60 in RTH."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    @staticmethod
+    def _std_ret(s: pd.Series) -> float:
+        r = s.pct_change().replace([np.inf, -np.inf], np.nan).dropna()
+        return float(r.std(ddof=1)) if len(r) >= 2 else np.nan
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz)
+        am = df.between_time("09:30", "10:29")
+        pm = df.between_time("15:00", "15:59")
+        df = df[df["symbol"].isin(sample["symbol"].unique())].copy()
+        for part in (am, pm):
+            part["close"] = pd.to_numeric(part["close"], errors="coerce")
+        am = am.dropna(subset=["close"])
+        pm = pm.dropna(subset=["close"])
+
+        res: dict[str, float] = {}
+        for sym in sample["symbol"].unique():
+            s_am = am[am["symbol"] == sym].sort_index()["close"]
+            s_pm = pm[pm["symbol"] == sym].sort_index()["close"]
+            sa = self._std_ret(s_am)
+            sp = self._std_ret(s_pm)
+            if not np.isfinite(sa) or not np.isfinite(sp) or sp == 0:
+                res[sym] = np.nan
+            else:
+                res[sym] = sa / sp
+
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = EarlyLateVolRatio60mFeature()

--- a/cube2mat/features/jump_count_local_k3_win21.py
+++ b/cube2mat/features/jump_count_local_k3_win21.py
@@ -1,0 +1,67 @@
+# features/jump_count_local_k3_win21.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class JumpCountLocalK3Win21Feature(BaseFeature):
+    """
+    基于局部 MAD 的跳数：
+      r = diff(log(close))；sigma_local = 1.4826*MAD(|r|) 右对齐滚动窗21。
+      计数 |r_t| > k*sigma_local, k=3。有效收益 <21 或无有效 sigma → NaN。
+    """
+
+    name = "jump_count_local_k3_win21"
+    description = "Count of |logret| > 3×local MAD scale (win=21)."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+    k = 3.0
+    window = 21
+
+    @staticmethod
+    def _mad(x: pd.Series) -> float:
+        m = x.median()
+        return 1.4826 * (x - m).abs().median()
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df.symbol.isin(sample.symbol.unique())]
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        k = float(self.k)
+        win = int(self.window)
+        res: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            r = np.log(g.sort_index()["close"]).diff().replace([np.inf, -np.inf], np.nan)
+            a = r.abs()
+            if a.dropna().shape[0] < win:
+                res[sym] = np.nan
+                continue
+            sigma = a.rolling(win).apply(lambda s: self._mad(pd.Series(s).dropna()), raw=False)
+            mask = (sigma > 0) & a.notna()
+            if mask.sum() < 1:
+                res[sym] = np.nan
+                continue
+            cnt = int(((a > k * sigma) & mask).sum())
+            res[sym] = float(cnt)
+
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = JumpCountLocalK3Win21Feature()

--- a/cube2mat/features/jump_count_local_q95.py
+++ b/cube2mat/features/jump_count_local_q95.py
@@ -1,0 +1,54 @@
+# features/jump_count_local_q95.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class JumpCountLocalQ95Feature(BaseFeature):
+    """
+    09:30–15:59 内，|logret| 超过其 95% 分位数的跳数。
+    有效收益 <10 时 NaN。
+    """
+
+    name = "jump_count_local_q95"
+    description = "Count of |logret| exceeding its 95% session quantile."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+    q = 0.95
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df.symbol.isin(sample.symbol.unique())]
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        res: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            a = (
+                np.log(g.sort_index()["close"]).diff().replace([np.inf, -np.inf], np.nan).abs().dropna()
+            )
+            if len(a) < 10:
+                res[sym] = np.nan
+                continue
+            thr = float(a.quantile(self.q))
+            res[sym] = float((a > thr).sum())
+
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = JumpCountLocalQ95Feature()

--- a/cube2mat/features/partial_corr_absret_volume_time.py
+++ b/cube2mat/features/partial_corr_absret_volume_time.py
@@ -1,0 +1,89 @@
+# features/partial_corr_absret_volume_time.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class PartialCorrAbsRetVolumeTimeFeature(BaseFeature):
+    """
+    控制线性时间趋势后，|logret| 与 volume 的偏相关。
+    步骤：
+      1) r = diff(log(close)); a = |r|
+      2) t = 分钟归一化 [0,1]，与 a 对齐
+      3) 分别对 a 和 volume 回归 [1,t]，取残差后相关
+    样本 <3 或任一方差=0 时 NaN。
+    """
+
+    name = "partial_corr_absret_volume_time"
+    description = "Partial corr(|logret|, volume | time) within RTH."
+    required_full_columns = ("symbol", "time", "close", "volume")
+    required_pv_columns = ("symbol",)
+
+    TOTAL_MIN = (
+        pd.Timedelta("15:59:00") - pd.Timedelta("09:30:00")
+    ).total_seconds() / 60.0
+
+    @staticmethod
+    def _corr(x: np.ndarray, y: np.ndarray) -> float:
+        if x.size < 3 or y.size < 3 or x.size != y.size:
+            return np.nan
+        xc = x - x.mean()
+        yc = y - y.mean()
+        sx = np.sqrt((xc * xc).sum())
+        sy = np.sqrt((yc * yc).sum())
+        if sx <= 0 or sy <= 0 or not np.isfinite(sx * sy):
+            return np.nan
+        return float((xc * yc).sum() / (sx * sy))
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df["symbol"].isin(sample["symbol"].unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = df.copy()
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df["volume"] = pd.to_numeric(df["volume"], errors="coerce")
+        df = df.dropna(subset=["close", "volume"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        res: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            g = g.sort_index()
+            r = np.log(g["close"]).diff().replace([np.inf, -np.inf], np.nan)
+            a = r.abs().iloc[1:]
+            v = g["volume"].iloc[1:]
+            t0 = g.index[0]
+            tf = ((g.index - t0).total_seconds() / 60.0) / self.TOTAL_MIN
+            tf = tf.iloc[1:]
+            df2 = pd.DataFrame({"a": a, "v": v, "t": tf}).dropna()
+            if len(df2) < 3:
+                res[sym] = np.nan
+                continue
+            n = len(df2)
+            X = np.column_stack([np.ones(n), df2["t"].to_numpy()])
+            beta_a, *_ = np.linalg.lstsq(X, df2["a"].to_numpy(), rcond=None)
+            beta_v, *_ = np.linalg.lstsq(X, df2["v"].to_numpy(), rcond=None)
+            res_a = df2["a"].to_numpy() - X @ beta_a
+            res_v = df2["v"].to_numpy() - X @ beta_v
+            res[sym] = self._corr(res_a, res_v)
+
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = PartialCorrAbsRetVolumeTimeFeature()

--- a/cube2mat/features/permutation_entropy_ret.py
+++ b/cube2mat/features/permutation_entropy_ret.py
@@ -1,0 +1,73 @@
+# features/permutation_entropy_ret.py
+from __future__ import annotations
+import datetime as dt
+import math
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class PermutationEntropyRetFeature(BaseFeature):
+    """
+    09:30–15:59 内 logret 的排列熵 (m=4, tau=1)，归一化至 [0,1]。
+    有效收益长度 < m+1 时 NaN。
+    """
+
+    name = "permutation_entropy_ret"
+    description = "Normalized permutation entropy of log returns (m=4, tau=1)."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+    m = 4
+    tau = 1
+
+    def _perm_entropy(self, x: np.ndarray, m: int, tau: int) -> float:
+        n = x.size
+        L = n - (m - 1) * tau
+        if L <= 1:
+            return np.nan
+        counts: dict[tuple[int, ...], int] = {}
+        for i in range(L):
+            seg = x[i : i + (m * tau) : tau]
+            ranks = np.argsort(np.argsort(seg, kind="mergesort"), kind="mergesort")
+            key = tuple(ranks.tolist())
+            counts[key] = counts.get(key, 0) + 1
+        cnt = np.array(list(counts.values()), dtype=float)
+        p = cnt / cnt.sum()
+        p = p[p > 0]
+        if p.size < 2:
+            return np.nan
+        H = float(-(p * np.log(p)).sum() / math.log(math.factorial(m)))
+        return float(np.clip(H, 0.0, 1.0))
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df.symbol.isin(sample.symbol.unique())].copy()
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        m = int(self.m)
+        tau = int(self.tau)
+        res: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            r = (
+                np.log(g.sort_index()["close"]).diff().replace([np.inf, -np.inf], np.nan).dropna().to_numpy()
+            )
+            res[sym] = self._perm_entropy(r, m, tau)
+
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = PermutationEntropyRetFeature()

--- a/cube2mat/features/rv_cond_above_vwap.py
+++ b/cube2mat/features/rv_cond_above_vwap.py
@@ -1,0 +1,55 @@
+# features/rv_cond_above_vwap.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class RVCondAboveVWAPFeature(BaseFeature):
+    """
+    仅在 close>vwap 时累积的 RV：∑ r^2 (logret)，对齐到收益终点。
+    有效收益 <3 或无满足条件的收益 → NaN。
+    """
+
+    name = "rv_cond_above_vwap"
+    description = "Sum of r^2 (logret) while close>vwap within RTH."
+    required_full_columns = ("symbol", "time", "close", "vwap")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59").copy()
+        for c in ("close", "vwap"):
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+        df = df.dropna(subset=["close", "vwap"])
+        df = df[df.symbol.isin(sample.symbol.unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        res: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            g = g.sort_index()
+            r = np.log(g["close"]).diff().replace([np.inf, -np.inf], np.nan)
+            r = r.iloc[1:]
+            state = (g["close"] > g["vwap"]).iloc[1:]
+            rr = (r * r)[state]
+            if rr.dropna().empty:
+                res[sym] = np.nan
+                continue
+            res[sym] = float(rr.sum())
+
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = RVCondAboveVWAPFeature()

--- a/cube2mat/features/rv_cond_below_vwap.py
+++ b/cube2mat/features/rv_cond_below_vwap.py
@@ -1,0 +1,52 @@
+# features/rv_cond_below_vwap.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class RVCondBelowVWAPFeature(BaseFeature):
+    """
+    仅在 close≤vwap 时累积的 RV：∑ r^2 (logret)，对齐到收益终点。
+    无满足条件的收益 → NaN。
+    """
+
+    name = "rv_cond_below_vwap"
+    description = "Sum of r^2 (logret) while close≤vwap within RTH."
+    required_full_columns = ("symbol", "time", "close", "vwap")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59").copy()
+        for c in ("close", "vwap"):
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+        df = df.dropna(subset=["close", "vwap"])
+        df = df[df.symbol.isin(sample.symbol.unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        res: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            g = g.sort_index()
+            r = np.log(g["close"]).diff().replace([np.inf, -np.inf], np.nan)
+            r = r.iloc[1:]
+            state = (g["close"] <= g["vwap"]).iloc[1:]
+            rr = (r * r)[state]
+            res[sym] = float(rr.sum()) if rr.notna().sum() >= 1 else np.nan
+
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = RVCondBelowVWAPFeature()

--- a/cube2mat/features/rv_cond_down.py
+++ b/cube2mat/features/rv_cond_down.py
@@ -1,0 +1,51 @@
+# features/rv_cond_down.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class RVCondDownFeature(BaseFeature):
+    """
+    仅在下行 bar (simple ret<0) 时累积的 RV：∑ r^2 (logret)。
+    无满足条件的收益 → NaN。
+    """
+
+    name = "rv_cond_down"
+    description = "RV contributed by down bars (simple ret<0) in RTH."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df.symbol.isin(sample.symbol.unique())].copy()
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        res: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            g = g.sort_index()
+            rlog = np.log(g["close"]).diff().replace([np.inf, -np.inf], np.nan)
+            rsimple = g["close"].pct_change()
+            mask = rsimple < 0
+            rr = (rlog * rlog)[mask]
+            res[sym] = float(rr.dropna().sum()) if rr.notna().sum() >= 1 else np.nan
+
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = RVCondDownFeature()

--- a/cube2mat/features/rv_cond_up.py
+++ b/cube2mat/features/rv_cond_up.py
@@ -1,0 +1,51 @@
+# features/rv_cond_up.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class RVCondUpFeature(BaseFeature):
+    """
+    仅在上行 bar (simple ret>0) 时累积的 RV：∑ r^2 (logret)。
+    无满足条件的收益 → NaN。
+    """
+
+    name = "rv_cond_up"
+    description = "RV contributed by up bars (simple ret>0) in RTH."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df.symbol.isin(sample.symbol.unique())].copy()
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        res: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            g = g.sort_index()
+            rlog = np.log(g["close"]).diff().replace([np.inf, -np.inf], np.nan)
+            rsimple = g["close"].pct_change()
+            mask = rsimple > 0
+            rr = (rlog * rlog)[mask]
+            res[sym] = float(rr.dropna().sum()) if rr.notna().sum() >= 1 else np.nan
+
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = RVCondUpFeature()

--- a/cube2mat/features/rv_last15m_share.py
+++ b/cube2mat/features/rv_last15m_share.py
@@ -1,0 +1,61 @@
+# features/rv_last15m_share.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class RVLast15mShareFeature(BaseFeature):
+    """
+    尾盘 15 分钟 (15:45–15:59) 对日内 RV 的贡献份额。
+    RV=∑ r^2, r=logret。总 RV<=0 或有效收益<3 → NaN。
+    """
+
+    name = "rv_last15m_share"
+    description = "Share of RV from 15:45–15:59 within RTH."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz)
+        rth = df.between_time("09:30", "15:59")
+        rth = rth[rth["symbol"].isin(sample["symbol"].unique())].copy()
+        rth["close"] = pd.to_numeric(rth["close"], errors="coerce")
+        rth = rth.dropna(subset=["close"])
+        if rth.empty:
+            out["value"] = pd.NA
+            return out
+
+        tail = rth.between_time("15:45", "15:59")
+        res: dict[str, float] = {}
+        for sym, g in rth.groupby("symbol", sort=False):
+            g = g.sort_index()
+            r = np.log(g["close"]).diff().replace([np.inf, -np.inf], np.nan).dropna()
+            if len(r) < 3:
+                res[sym] = np.nan
+                continue
+            total = float((r * r).sum())
+            if total <= 0 or not np.isfinite(total):
+                res[sym] = np.nan
+                continue
+            idx = g.index
+            r.index = idx[1:]
+            mask = r.index.isin(tail.index)
+            share = float((r[mask] ** 2).sum() / total)
+            res[sym] = share
+
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = RVLast15mShareFeature()

--- a/cube2mat/features/wavelet_energy_lowfreq_share.py
+++ b/cube2mat/features/wavelet_energy_lowfreq_share.py
@@ -1,0 +1,88 @@
+# features/wavelet_energy_lowfreq_share.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class WaveletEnergyLowfreqShareFeature(BaseFeature):
+    """
+    Haar 小波分解后，近似系数能量占比：
+      - close 对时间做 OLS 去趋势并去均值
+      - 进行 L=3 级 Haar 分解，取最终近似 a_L
+      - value = sum(a_L^2) / sum(残差^2)
+    样本不足或总能量<=0 → NaN。
+    """
+
+    name = "wavelet_energy_lowfreq_share"
+    description = "Haar-DWT low-frequency energy share of detrended close (L=3)."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+    L = 3
+
+    @staticmethod
+    def _haar_levels(y: np.ndarray, L: int) -> np.ndarray | None:
+        a = y.copy()
+        for _ in range(L):
+            n = a.size
+            if n < 2:
+                return None
+            if n % 2 == 1:
+                a = np.append(a, a[-1])
+                n += 1
+            a_next = (a[0::2] + a[1::2]) / np.sqrt(2.0)
+            a = a_next
+        return a
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df.symbol.isin(sample.symbol.unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+        df = df.copy()
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        L = int(self.L)
+        res: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            y = g.sort_index()["close"].to_numpy(dtype=float)
+            n = y.size
+            if n < 8:
+                res[sym] = np.nan
+                continue
+            t = np.linspace(0.0, 1.0, n, endpoint=True)
+            X = np.column_stack([np.ones(n), t])
+            beta, *_ = np.linalg.lstsq(X, y, rcond=None)
+            e = y - X @ beta
+            e = e - e.mean()
+            tot = float((e * e).sum())
+            if tot <= 0 or not np.isfinite(tot):
+                res[sym] = np.nan
+                continue
+            aL = self._haar_levels(e, min(L, int(np.floor(np.log2(max(2, n))))))
+            if aL is None or aL.size < 1:
+                res[sym] = np.nan
+                continue
+            low = float((aL * aL).sum())
+            res[sym] = float(np.clip(low / tot, 0.0, 1.0))
+
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = WaveletEnergyLowfreqShareFeature()

--- a/cube2mat/features/xcorr_sign_volume_leadlag_lag.py
+++ b/cube2mat/features/xcorr_sign_volume_leadlag_lag.py
@@ -1,0 +1,89 @@
+# features/xcorr_sign_volume_leadlag_lag.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class XCorrSignVolumeLeadLagLagFeature(BaseFeature):
+    """
+    sign(simple ret) 与 volume 滞后互相关峰值所在的滞后：
+      计算 Corr(sign_ret_t, volume_{t+lag})，lag ∈ [-K,K]，
+      返回使 |corr| 最大的 lag（负值表示量领先）。样本不足时 NaN。
+    """
+
+    name = "xcorr_sign_volume_leadlag_lag"
+    description = "Lag of peak |corr(sign(ret), volume shift)| over [-5,5] in RTH."
+    required_full_columns = ("symbol", "time", "close", "volume")
+    required_pv_columns = ("symbol",)
+    K = 5
+
+    @staticmethod
+    def _corr(x: np.ndarray, y: np.ndarray) -> float:
+        if x.size < 3 or y.size < 3 or x.size != y.size:
+            return np.nan
+        xc = x - x.mean()
+        yc = y - y.mean()
+        sx = np.sqrt((xc * xc).sum())
+        sy = np.sqrt((yc * yc).sum())
+        if sx <= 0 or sy <= 0 or not np.isfinite(sx * sy):
+            return np.nan
+        return float((xc * yc).sum() / (sx * sy))
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59").copy()
+        for c in ("close", "volume"):
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+        df = df.dropna(subset=["close", "volume"])
+        df = df[df.symbol.isin(sample.symbol.unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        K = int(self.K)
+        res: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            g = g.sort_index()
+            sgn = np.sign(g["close"].pct_change()).to_numpy(dtype=float)
+            v = g["volume"].to_numpy(dtype=float)
+            n = sgn.size
+            if n < K + 3:
+                res[sym] = np.nan
+                continue
+            best = np.nan
+            bestlag = np.nan
+            for lag in range(-K, K + 1):
+                if lag < 0:
+                    x = sgn[-lag:]
+                    y = v[: n + lag]
+                elif lag > 0:
+                    x = sgn[: -lag]
+                    y = v[lag:]
+                else:
+                    x = sgn
+                    y = v
+                x = x[1:]
+                if x.size < 3 or y.size < 3 or x.size != y.size:
+                    continue
+                c = self._corr(x, y)
+                if np.isfinite(c):
+                    if not np.isfinite(best) or abs(c) > abs(best):
+                        best = c
+                        bestlag = float(lag)
+            res[sym] = bestlag
+
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = XCorrSignVolumeLeadLagLagFeature()

--- a/cube2mat/features/xcorr_sign_volume_leadlag_peak.py
+++ b/cube2mat/features/xcorr_sign_volume_leadlag_peak.py
@@ -1,0 +1,87 @@
+# features/xcorr_sign_volume_leadlag_peak.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class XCorrSignVolumeLeadLagPeakFeature(BaseFeature):
+    """
+    sign(simple ret) 与 volume 的滞后互相关峰值：
+      计算 Corr(sign_ret_t, volume_{t+lag})，lag ∈ [-K,K]，返回最大绝对值。
+    样本不足时 NaN。
+    """
+
+    name = "xcorr_sign_volume_leadlag_peak"
+    description = "Peak |corr(sign(ret), volume shift)| over lags [-5,5] in RTH."
+    required_full_columns = ("symbol", "time", "close", "volume")
+    required_pv_columns = ("symbol",)
+    K = 5
+
+    @staticmethod
+    def _corr(x: np.ndarray, y: np.ndarray) -> float:
+        if x.size < 3 or y.size < 3 or x.size != y.size:
+            return np.nan
+        xc = x - x.mean()
+        yc = y - y.mean()
+        sx = np.sqrt((xc * xc).sum())
+        sy = np.sqrt((yc * yc).sum())
+        if sx <= 0 or sy <= 0 or not np.isfinite(sx * sy):
+            return np.nan
+        return float((xc * yc).sum() / (sx * sy))
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        full = self.load_full(ctx, date, list(self.required_full_columns))
+        sample = self.load_pv(ctx, date, list(self.required_pv_columns))
+        if full is None or sample is None:
+            return None
+        out = sample[["symbol"]].copy()
+        if full.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(full, "time", ctx.tz).between_time("09:30", "15:59").copy()
+        for c in ("close", "volume"):
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+        df = df.dropna(subset=["close", "volume"])
+        df = df[df.symbol.isin(sample.symbol.unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        K = int(self.K)
+        res: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            g = g.sort_index()
+            sgn = np.sign(g["close"].pct_change()).to_numpy(dtype=float)
+            v = g["volume"].to_numpy(dtype=float)
+            n = sgn.size
+            if n < K + 3:
+                res[sym] = np.nan
+                continue
+            best = np.nan
+            for lag in range(-K, K + 1):
+                if lag < 0:
+                    x = sgn[-lag:]
+                    y = v[: n + lag]
+                elif lag > 0:
+                    x = sgn[: -lag]
+                    y = v[lag:]
+                else:
+                    x = sgn
+                    y = v
+                x = x[1:]
+                if x.size < 3 or y.size < 3 or x.size != y.size:
+                    continue
+                c = self._corr(x, y)
+                if np.isfinite(c):
+                    if not np.isfinite(best) or abs(c) > abs(best):
+                        best = c
+            res[sym] = best
+
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = XCorrSignVolumeLeadLagPeakFeature()


### PR DESCRIPTION
## Summary
- add features for return-volume and close-VWAP correlations
- add partial correlations, realized variance components, and volatility ratio metrics
- add permutation entropy, wavelet energy share, jump counts, and lead-lag cross-correlations

## Testing
- `pytest -q` *(fails: No module named 'pandas')*
- `pip install pandas -q` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f2c564e4832a8e0cfe64dc66d101