### PR TITLE
feat: add diverse VWAP and volume features

### DIFF
--- a/cube2mat/features/accel_over_vel_std_ratio.py
+++ b/cube2mat/features/accel_over_vel_std_ratio.py
@@ -1,0 +1,55 @@
+# features/accel_over_vel_std_ratio.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class AccelOverVelStdRatioFeature(BaseFeature):
+    """
+    Ratio of std(Δ²close) to std(Δclose) within RTH; measures curvature vs. velocity.
+    Returns NaN if insufficient data or denominator is 0.
+    """
+
+    name = "accel_over_vel_std_ratio"
+    description = "Std(second diff of close) / Std(first diff of close) in RTH."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, ["symbol", "time", "close"])
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if df is None or sample is None:
+            return None
+
+        out = sample[["symbol"]].copy()
+        if df.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(df, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df.symbol.isin(sample.symbol.unique())]
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        res: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            s = g.sort_index()["close"].to_numpy(dtype=float)
+            if s.size < 4:
+                res[sym] = np.nan
+                continue
+            d1 = np.diff(s)
+            d2 = np.diff(d1)
+            sd1 = float(np.std(d1, ddof=1)) if d1.size >= 2 else np.nan
+            sd2 = float(np.std(d2, ddof=1)) if d2.size >= 2 else np.nan
+            res[sym] = (sd2 / sd1) if (np.isfinite(sd1) and sd1 > 0 and np.isfinite(sd2)) else np.nan
+
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = AccelOverVelStdRatioFeature()

--- a/cube2mat/features/corr_ret_n.py
+++ b/cube2mat/features/corr_ret_n.py
@@ -1,0 +1,62 @@
+# features/corr_ret_n.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class CorrRetNFeature(BaseFeature):
+    """
+    Pearson correlation between signed log returns and trade count n in RTH.
+    """
+
+    name = "corr_ret_n"
+    description = "Correlation of log returns and trade count n (RTH)."
+    required_full_columns = ("symbol", "time", "close", "n")
+    required_pv_columns = ("symbol",)
+
+    @staticmethod
+    def _corr(x: np.ndarray, y: np.ndarray) -> float:
+        if x.size != y.size or x.size < 3:
+            return np.nan
+        xc = x - x.mean()
+        yc = y - y.mean()
+        sx = float(np.sqrt(np.sum(xc * xc)))
+        sy = float(np.sqrt(np.sum(yc * yc)))
+        if sx <= 0 or sy <= 0 or not np.isfinite(sx * sy):
+            return np.nan
+        return float(np.sum(xc * yc) / (sx * sy))
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, ["symbol", "time", "close", "n"])
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if df is None or sample is None:
+            return None
+
+        out = sample[["symbol"]].copy()
+        if df.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(df, "time", ctx.tz).between_time("09:30", "15:59").copy()
+        for c in ("close", "n"):
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+        df = df.dropna(subset=["close", "n"])
+        df = df[df.symbol.isin(sample.symbol.unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        res: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            g = g.sort_index()
+            r = np.log(g["close"]).diff().replace([np.inf, -np.inf], np.nan)
+            xy = pd.concat([r, g["n"]], axis=1).dropna()
+            res[sym] = self._corr(xy.iloc[:, 0].to_numpy(), xy.iloc[:, 1].to_numpy())
+
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = CorrRetNFeature()

--- a/cube2mat/features/cv_trade_size.py
+++ b/cube2mat/features/cv_trade_size.py
@@ -1,0 +1,49 @@
+# features/cv_trade_size.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class CVTradeSizeFeature(BaseFeature):
+    """
+    Coefficient of variation of per-bar average trade size ts = volume / n
+    using bars with n > 0 within RTH.
+    """
+
+    name = "cv_trade_size"
+    description = "Std/mean of per-bar trade size (volume/n) in RTH."
+    required_full_columns = ("symbol", "time", "volume", "n")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, ["symbol", "time", "volume", "n"])
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if df is None or sample is None:
+            return None
+
+        out = sample[["symbol"]].copy()
+        if df.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(df, "time", ctx.tz).between_time("09:30", "15:59").copy()
+        for c in ("volume", "n"):
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+        df = df.dropna(subset=["volume", "n"])
+        df = df[df["n"] > 0]
+        df = df[df.symbol.isin(sample.symbol.unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        ts = df["volume"] / df["n"]
+        res = df.assign(ts=ts).groupby("symbol")["ts"].apply(
+            lambda s: float(s.std(ddof=1) / s.mean()) if (len(s) >= 3 and s.mean() > 0) else np.nan
+        )
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = CVTradeSizeFeature()

--- a/cube2mat/features/entropy_sign_ret.py
+++ b/cube2mat/features/entropy_sign_ret.py
@@ -1,0 +1,64 @@
+# features/entropy_sign_ret.py
+from __future__ import annotations
+import datetime as dt
+import math
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class EntropySignRetFeature(BaseFeature):
+    """
+    Normalized Shannon entropy of simple-return signs in RTH:
+    states = {-1, 0, +1}; H = -sum p_i log p_i / log(k), where k is number of states with
+    non-zero probability. Returns NaN if fewer than one return or only one state present.
+    """
+
+    name = "entropy_sign_ret"
+    description = "Normalized entropy (0..1) of simple-return sign distribution."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, ["symbol", "time", "close"])
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if df is None or sample is None:
+            return None
+
+        out = sample[["symbol"]].copy()
+        if df.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(df, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df.symbol.isin(sample.symbol.unique())].copy()
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        res: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            r = (
+                g.sort_index()["close"].pct_change().replace([np.inf, -np.inf], np.nan).dropna()
+            )
+            if len(r) < 1:
+                res[sym] = np.nan
+                continue
+            s = np.sign(r.values)
+            vals, counts = np.unique(s, return_counts=True)
+            p = counts / counts.sum()
+            p = p[p > 0]
+            k = p.size
+            if k < 2:
+                res[sym] = np.nan
+                continue
+            H = -np.sum(p * np.log(p)) / math.log(k)
+            res[sym] = float(np.clip(H, 0.0, 1.0))
+
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = EntropySignRetFeature()

--- a/cube2mat/features/ewma_rvol_logret_094.py
+++ b/cube2mat/features/ewma_rvol_logret_094.py
@@ -1,0 +1,60 @@
+# features/ewma_rvol_logret_094.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class EWMARVolLogret094Feature(BaseFeature):
+    """
+    EWMA realized volatility (lambda=0.94) of intraday log returns within RTH.
+    Weights normalized to sum to 1:
+      w_i = (1 - λ) / (1 - λ^n) * λ^{n-1-i}; sigma = sqrt(sum w_i r_i^2).
+    """
+
+    name = "ewma_rvol_logret_094"
+    description = "RiskMetrics-style EWMA RV (lambda=0.94) on log returns (RTH)."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+    lam = 0.94
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, ["symbol", "time", "close"])
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if df is None or sample is None:
+            return None
+
+        out = sample[["symbol"]].copy()
+        if df.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(df, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df.symbol.isin(sample.symbol.unique())]
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        l = float(self.lam)
+        res: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            r = (
+                np.log(g.sort_index()["close"]).diff().replace([np.inf, -np.inf], np.nan).dropna()
+            ).to_numpy()
+            n = r.size
+            if n < 3:
+                res[sym] = np.nan
+                continue
+            w = (1 - l) * l ** np.arange(n - 1, -1, -1)
+            w = w / w.sum()
+            sigma = float(np.sqrt(np.sum(w * (r * r))))
+            res[sym] = sigma if np.isfinite(sigma) else np.nan
+
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = EWMARVolLogret094Feature()

--- a/cube2mat/features/gini_absret.py
+++ b/cube2mat/features/gini_absret.py
@@ -1,0 +1,65 @@
+# features/gini_absret.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _gini(x: np.ndarray) -> float:
+    x = np.asarray(x, float)
+    x = x[np.isfinite(x) & (x >= 0)]
+    n = x.size
+    s = x.sum()
+    if n < 2 or s <= 0:
+        return np.nan
+    xs = np.sort(x)
+    i = np.arange(1, n + 1)
+    g = 1.0 - 2.0 * np.sum((n - i + 0.5) * xs) / (n * s)
+    return float(np.clip(g, 0.0, 1.0))
+
+
+class GiniAbsRetFeature(BaseFeature):
+    """
+    Gini of |log returns| across RTH bars. Complement to RV Gini (which uses r^2).
+    """
+
+    name = "gini_absret"
+    description = "Gini concentration of |logret| magnitudes within RTH."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, ["symbol", "time", "close"])
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if df is None or sample is None:
+            return None
+
+        out = sample[["symbol"]].copy()
+        if df.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(df, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df.symbol.isin(sample.symbol.unique())]
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        res = df.groupby("symbol").apply(
+            lambda g: _gini(
+                np.abs(
+                    np.log(g.sort_index()["close"])  # type: ignore
+                    .diff()
+                    .dropna()
+                    .values
+                )
+            )
+        )
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = GiniAbsRetFeature()

--- a/cube2mat/features/mean_close_vwap_rel_diff.py
+++ b/cube2mat/features/mean_close_vwap_rel_diff.py
@@ -1,0 +1,46 @@
+# features/mean_close_vwap_rel_diff.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class MeanCloseVWAPRelDiffFeature(BaseFeature):
+    """
+    Mean relative premium of close vs vwap: mean((close - vwap) / vwap) in RTH.
+    """
+
+    name = "mean_close_vwap_rel_diff"
+    description = "Average (close - vwap)/vwap over RTH bars."
+    required_full_columns = ("symbol", "time", "close", "vwap")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, ["symbol", "time", "close", "vwap"])
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if df is None or sample is None:
+            return None
+
+        out = sample[["symbol"]].copy()
+        if df.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(df, "time", ctx.tz).between_time("09:30", "15:59").copy()
+        for c in ("close", "vwap"):
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+        df = df.dropna(subset=["close", "vwap"])
+        df = df[df.symbol.isin(sample.symbol.unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        res = df.groupby("symbol").apply(
+            lambda g: float(((g["close"] - g["vwap"]) / g["vwap"]).mean()) if len(g) > 0 else np.nan
+        )
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = MeanCloseVWAPRelDiffFeature()

--- a/cube2mat/features/mean_run_length_sign.py
+++ b/cube2mat/features/mean_run_length_sign.py
@@ -1,0 +1,63 @@
+# features/mean_run_length_sign.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class MeanRunLengthSignFeature(BaseFeature):
+    """
+    Mean run length of non-zero simple-return signs in RTH (combine up & down runs).
+    Returns NaN if fewer than two non-zero signs or no runs.
+    """
+
+    name = "mean_run_length_sign"
+    description = "Average length of consecutive non-zero sign runs (RTH)."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    @staticmethod
+    def _mean_runlen(sign: np.ndarray) -> float:
+        s = sign[sign != 0]
+        if s.size < 2:
+            return np.nan
+        runs: list[int] = []
+        cur = 1
+        for i in range(1, s.size):
+            if s[i] == s[i - 1]:
+                cur += 1
+            else:
+                runs.append(cur)
+                cur = 1
+        runs.append(cur)
+        return float(np.mean(runs)) if runs else np.nan
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, ["symbol", "time", "close"])
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if df is None or sample is None:
+            return None
+
+        out = sample[["symbol"]].copy()
+        if df.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(df, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df.symbol.isin(sample.symbol.unique())].copy()
+        df["close"] = pd.to_numeric(df["close"], errors="coerce")
+        df = df.dropna(subset=["close"])
+
+        res: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            r = (
+                g.sort_index()["close"].pct_change().replace([np.inf, -np.inf], np.nan).dropna()
+            ).to_numpy()
+            res[sym] = self._mean_runlen(np.sign(r)) if r.size > 0 else np.nan
+
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = MeanRunLengthSignFeature()

--- a/cube2mat/features/n_front_loading_score.py
+++ b/cube2mat/features/n_front_loading_score.py
@@ -1,0 +1,70 @@
+# features/n_front_loading_score.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class NFrontLoadingScoreFeature(BaseFeature):
+    """
+    Front-loading score for trade counts:
+    y = cumsum(n) / sum(n) vs x = time fraction in [0, 1];
+    score = 2 * AUC(y over x) - 1 in [-1, 1].
+    """
+
+    name = "n_front_loading_score"
+    description = "2*AUC(cum n fraction vs time fraction)-1 in RTH."
+    required_full_columns = ("symbol", "time", "n")
+    required_pv_columns = ("symbol",)
+
+    TOTAL_MIN = (
+        pd.Timedelta("15:59:00") - pd.Timedelta("09:30:00")
+    ).total_seconds() / 60.0
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, ["symbol", "time", "n"])
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if df is None or sample is None:
+            return None
+
+        out = sample[["symbol"]].copy()
+        if df.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(df, "time", ctx.tz).between_time("09:30", "15:59").copy()
+        df["n"] = pd.to_numeric(df["n"], errors="coerce")
+        df = df.dropna(subset=["n"])
+        df = df[df.symbol.isin(sample.symbol.unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        res: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            g = g.sort_index()
+            total = float(g["n"].sum())
+            if total <= 0:
+                res[sym] = np.nan
+                continue
+            start = g.index[0]
+            x = ((g.index - start).total_seconds() / 60.0) / self.TOTAL_MIN
+            y = g["n"].cumsum() / total
+            xa = x.to_numpy()
+            ya = y.to_numpy()
+            if xa[0] > 0:
+                xa = np.insert(xa, 0, 0.0)
+                ya = np.insert(ya, 0, 0.0)
+            if xa[-1] < 1:
+                xa = np.append(xa, 1.0)
+                ya = np.append(ya, 1.0)
+            auc = float(np.trapz(ya, xa))
+            score = 2 * auc - 1
+            res[sym] = float(np.clip(score, -1.0, 1.0))
+
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = NFrontLoadingScoreFeature()

--- a/cube2mat/features/range_on_logvolume_beta.py
+++ b/cube2mat/features/range_on_logvolume_beta.py
@@ -1,0 +1,61 @@
+# features/range_on_logvolume_beta.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class RangeOnLogVolumeBetaFeature(BaseFeature):
+    """
+    OLS slope for (high - low) ~ 1 + log(volume) within RTH.
+    Returns NaN if variance of log(volume) is 0 or insufficient data.
+    """
+
+    name = "range_on_logvolume_beta"
+    description = "OLS beta of (high-low) on log(volume) in RTH."
+    required_full_columns = ("symbol", "time", "high", "low", "volume")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        cols = ["symbol", "time", "high", "low", "volume"]
+        df = self.load_full(ctx, date, cols)
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if df is None or sample is None:
+            return None
+
+        out = sample[["symbol"]].copy()
+        if df.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(df, "time", ctx.tz).between_time("09:30", "15:59").copy()
+        for c in ("high", "low", "volume"):
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+        df = df.dropna(subset=["high", "low", "volume"])
+        df = df[df.symbol.isin(sample.symbol.unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        df["range"] = df["high"] - df["low"]
+        df = df[df["range"] >= 0]
+
+        res: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            g = g.sort_index()
+            x = np.log(g["volume"].replace(0, np.nan))
+            y = g["range"]
+            xy = pd.concat([x, y], axis=1).dropna()
+            if len(xy) < 3 or xy.iloc[:, 0].var() == 0:
+                res[sym] = np.nan
+                continue
+            X = np.column_stack([np.ones(len(xy)), xy.iloc[:, 0].to_numpy()])
+            beta, _ = np.linalg.lstsq(X, xy.iloc[:, 1].to_numpy(), rcond=None)
+            res[sym] = float(beta[1])
+
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = RangeOnLogVolumeBetaFeature()

--- a/cube2mat/features/ret_next_on_vwapdev_beta.py
+++ b/cube2mat/features/ret_next_on_vwapdev_beta.py
@@ -1,0 +1,58 @@
+# features/ret_next_on_vwapdev_beta.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class RetNextOnVWAPDevBetaFeature(BaseFeature):
+    """
+    OLS slope of next simple return on normalized deviation d_t = (close - vwap) / vwap.
+    y = ret_{t+1}; x = d_t within RTH.
+    Returns NaN if insufficient data or zero variance.
+    """
+
+    name = "ret_next_on_vwapdev_beta"
+    description = "Beta of next ret on (close-vwap)/vwap deviation (RTH)."
+    required_full_columns = ("symbol", "time", "close", "vwap")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, ["symbol", "time", "close", "vwap"])
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if df is None or sample is None:
+            return None
+
+        out = sample[["symbol"]].copy()
+        if df.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(df, "time", ctx.tz).between_time("09:30", "15:59").copy()
+        for c in ("close", "vwap"):
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+        df = df.dropna(subset=["close", "vwap"])
+        df = df[df.symbol.isin(sample.symbol.unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        res: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            g = g.sort_index()
+            dv = (g["close"] - g["vwap"]) / g["vwap"]
+            y = g["close"].pct_change().shift(-1)
+            xy = pd.concat([dv, y], axis=1).dropna()
+            if len(xy) < 3 or xy.iloc[:, 0].var() == 0:
+                res[sym] = np.nan
+                continue
+            X = np.column_stack([np.ones(len(xy)), xy.iloc[:, 0].to_numpy()])
+            beta, _ = np.linalg.lstsq(X, xy.iloc[:, 1].to_numpy(), rcond=None)
+            res[sym] = float(beta[1])
+
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = RetNextOnVWAPDevBetaFeature()

--- a/cube2mat/features/time_to_50pct_volume_frac.py
+++ b/cube2mat/features/time_to_50pct_volume_frac.py
@@ -1,0 +1,60 @@
+# features/time_to_50pct_volume_frac.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class TimeTo50PctVolumeFracFeature(BaseFeature):
+    """
+    Fraction of RTH minutes to reach 50% cumulative volume; range [0, 1].
+    Returns NaN if total volume <= 0.
+    """
+
+    name = "time_to_50pct_volume_frac"
+    description = "Session fraction to reach 50% of cumulative volume."
+    required_full_columns = ("symbol", "time", "volume")
+    required_pv_columns = ("symbol",)
+
+    TOTAL_MIN = (
+        pd.Timedelta("15:59:00") - pd.Timedelta("09:30:00")
+    ).total_seconds() / 60.0
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, ["symbol", "time", "volume"])
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if df is None or sample is None:
+            return None
+
+        out = sample[["symbol"]].copy()
+        if df.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(df, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df.symbol.isin(sample.symbol.unique())].copy()
+        df["volume"] = pd.to_numeric(df["volume"], errors="coerce")
+        df = df.dropna(subset=["volume"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        res: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            g = g.sort_index()
+            total = float(g["volume"].sum())
+            if total <= 0:
+                res[sym] = np.nan
+                continue
+            idx = int(min(g["volume"].cumsum().searchsorted(0.5 * total), len(g) - 1))
+            t = g.index[idx]
+            start = g.index[0]
+            frac = float(((t - start).total_seconds() / 60.0) / self.TOTAL_MIN)
+            res[sym] = float(np.clip(frac, 0.0, 1.0))
+
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = TimeTo50PctVolumeFracFeature()

--- a/cube2mat/features/time_to_50pct_volume_min.py
+++ b/cube2mat/features/time_to_50pct_volume_min.py
@@ -1,0 +1,58 @@
+# features/time_to_50pct_volume_min.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class TimeTo50PctVolumeMinFeature(BaseFeature):
+    """
+    Minutes since 09:30 to reach 50% of cumulative volume within RTH.
+    Returns NaN if total volume <= 0.
+    """
+
+    name = "time_to_50pct_volume_min"
+    description = "Absolute minutes required to reach 50% of session volume."
+    required_full_columns = ("symbol", "time", "volume")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, ["symbol", "time", "volume"])
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if df is None or sample is None:
+            return None
+
+        out = sample[["symbol"]].copy()
+        if df.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(df, "time", ctx.tz).between_time("09:30", "15:59")
+        df = df[df.symbol.isin(sample.symbol.unique())].copy()
+        df["volume"] = pd.to_numeric(df["volume"], errors="coerce")
+        df = df.dropna(subset=["volume"])
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        res: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            g = g.sort_index()
+            total = float(g["volume"].sum())
+            if total <= 0:
+                res[sym] = np.nan
+                continue
+            cum = g["volume"].cumsum()
+            idx = cum.searchsorted(0.5 * total)
+            idx = int(min(idx, len(g) - 1))
+            t = g.index[idx]
+            start = g.index[0]
+            minutes = float((t - start).total_seconds() / 60.0)
+            res[sym] = minutes
+
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = TimeTo50PctVolumeMinFeature()

--- a/cube2mat/features/vwap_avg_run_length_above.py
+++ b/cube2mat/features/vwap_avg_run_length_above.py
@@ -1,0 +1,65 @@
+# features/vwap_avg_run_length_above.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class VWAPAvgRunLengthAboveFeature(BaseFeature):
+    """
+    Mean run length (in bars) where close > vwap within RTH.
+    Returns NaN if no positive runs.
+    """
+
+    name = "vwap_avg_run_length_above"
+    description = "Average length of contiguous runs with close>vwap in RTH."
+    required_full_columns = ("symbol", "time", "close", "vwap")
+    required_pv_columns = ("symbol",)
+
+    @staticmethod
+    def _mean_run_len(x: np.ndarray) -> float:
+        if x.size == 0:
+            return np.nan
+        runs: list[int] = []
+        cnt = 0
+        for v in x:
+            if v:
+                cnt += 1
+            elif cnt > 0:
+                runs.append(cnt)
+                cnt = 0
+        if cnt > 0:
+            runs.append(cnt)
+        return float(np.mean(runs)) if runs else np.nan
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, ["symbol", "time", "close", "vwap"])
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if df is None or sample is None:
+            return None
+
+        out = sample[["symbol"]].copy()
+        if df.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(df, "time", ctx.tz).between_time("09:30", "15:59").copy()
+        for c in ("close", "vwap"):
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+        df = df.dropna(subset=["close", "vwap"])
+        df = df[df.symbol.isin(sample.symbol.unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        res: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            mask = (g.sort_index()["close"] > g["vwap"]).to_numpy()
+            res[sym] = self._mean_run_len(mask)
+
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = VWAPAvgRunLengthAboveFeature()

--- a/cube2mat/features/vwap_cross_count.py
+++ b/cube2mat/features/vwap_cross_count.py
@@ -1,0 +1,59 @@
+# features/vwap_cross_count.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class VWAPCrossCountFeature(BaseFeature):
+    """
+    Count of strict sign flips between close and vwap within RTH.
+    Crossing occurs when sign(diff_t) * sign(diff_{t-1}) < 0, ignoring zeros.
+    """
+
+    name = "vwap_cross_count"
+    description = "Number of strict sign flips of (close - vwap) in RTH."
+    required_full_columns = ("symbol", "time", "close", "vwap")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, ["symbol", "time", "close", "vwap"])
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if df is None or sample is None:
+            return None
+
+        out = sample[["symbol"]].copy()
+        if df.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(df, "time", ctx.tz).between_time("09:30", "15:59").copy()
+        for c in ("close", "vwap"):
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+        df = df.dropna(subset=["close", "vwap"])
+        df = df[df.symbol.isin(sample.symbol.unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        res: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            diff = (g.sort_index()["close"] - g.sort_index()["vwap"]).to_numpy(dtype=float)
+            if diff.size < 2:
+                res[sym] = np.nan
+                continue
+            s = np.sign(diff)
+            mask = s != 0
+            s = s[mask]
+            if s.size < 2:
+                res[sym] = np.nan
+                continue
+            crosses = int(np.sum(s[1:] * s[:-1] < 0))
+            res[sym] = float(crosses)
+
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = VWAPCrossCountFeature()

--- a/cube2mat/features/vwap_cross_down_nextret.py
+++ b/cube2mat/features/vwap_cross_down_nextret.py
@@ -1,0 +1,54 @@
+# features/vwap_cross_down_nextret.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class VWAPCrossDownNextRetFeature(BaseFeature):
+    """
+    Mean next simple return conditional on downward crossing:
+    event when (close - vwap) turns from >= 0 to < 0.
+    Returns NaN if fewer than 3 events.
+    """
+
+    name = "vwap_cross_down_nextret"
+    description = "Mean next ret after downward VWAP crossing in RTH."
+    required_full_columns = ("symbol", "time", "close", "vwap")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, ["symbol", "time", "close", "vwap"])
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if df is None or sample is None:
+            return None
+
+        out = sample[["symbol"]].copy()
+        if df.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(df, "time", ctx.tz).between_time("09:30", "15:59").copy()
+        for c in ("close", "vwap"):
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+        df = df.dropna(subset=["close", "vwap"])
+        df = df[df.symbol.isin(sample.symbol.unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        res: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            g = g.sort_index()
+            d = g["close"] - g["vwap"]
+            down = (d < 0) & (d.shift(1) >= 0)
+            nxt = g["close"].pct_change().shift(-1)
+            vals = nxt[down].dropna()
+            res[sym] = float(vals.mean()) if len(vals) >= 3 else np.nan
+
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = VWAPCrossDownNextRetFeature()

--- a/cube2mat/features/vwap_cross_up_nextret.py
+++ b/cube2mat/features/vwap_cross_up_nextret.py
@@ -1,0 +1,54 @@
+# features/vwap_cross_up_nextret.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class VWAPCrossUpNextRetFeature(BaseFeature):
+    """
+    Mean next simple return conditional on upward crossing:
+    event when (close - vwap) turns from <= 0 to > 0.
+    Next ret = pct_change(close).shift(-1). Returns NaN if fewer than 3 events.
+    """
+
+    name = "vwap_cross_up_nextret"
+    description = "Mean next ret after upward VWAP crossing in RTH."
+    required_full_columns = ("symbol", "time", "close", "vwap")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, ["symbol", "time", "close", "vwap"])
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if df is None or sample is None:
+            return None
+
+        out = sample[["symbol"]].copy()
+        if df.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(df, "time", ctx.tz).between_time("09:30", "15:59").copy()
+        for c in ("close", "vwap"):
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+        df = df.dropna(subset=["close", "vwap"])
+        df = df[df.symbol.isin(sample.symbol.unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        res: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            g = g.sort_index()
+            d = g["close"] - g["vwap"]
+            up = (d > 0) & (d.shift(1) <= 0)
+            nxt = g["close"].pct_change().shift(-1)
+            vals = nxt[up].dropna()
+            res[sym] = float(vals.mean()) if len(vals) >= 3 else np.nan
+
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = VWAPCrossUpNextRetFeature()

--- a/cube2mat/features/vwap_dev_ar1_halflife_bars.py
+++ b/cube2mat/features/vwap_dev_ar1_halflife_bars.py
@@ -1,0 +1,66 @@
+# features/vwap_dev_ar1_halflife_bars.py
+from __future__ import annotations
+import datetime as dt
+from math import log
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class VWAPDevAR1HalfLifeBarsFeature(BaseFeature):
+    """
+    Half-life (in bars) of deviation d_t = close - vwap under AR(1):
+      d_t = c + phi * d_{t-1} + e.
+    Half-life = -ln(2)/ln(phi) if 0 < phi < 1; otherwise NaN.
+    """
+
+    name = "vwap_dev_ar1_halflife_bars"
+    description = "AR(1) half-life of (close - vwap) deviation in RTH (bars)."
+    required_full_columns = ("symbol", "time", "close", "vwap")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, ["symbol", "time", "close", "vwap"])
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if df is None or sample is None:
+            return None
+
+        out = sample[["symbol"]].copy()
+        if df.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(df, "time", ctx.tz).between_time("09:30", "15:59").copy()
+        for c in ("close", "vwap"):
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+        df = df.dropna(subset=["close", "vwap"])
+        df = df[df.symbol.isin(sample.symbol.unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        res: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            d = (g.sort_index()["close"] - g["vwap"]).to_numpy(dtype=float)
+            if d.size < 3:
+                res[sym] = np.nan
+                continue
+            y = d[1:]
+            x = d[:-1]
+            X = np.column_stack([np.ones(x.size), x])
+            try:
+                beta, _ = np.linalg.lstsq(X, y, rcond=None)
+                phi = float(beta[1])
+                if 0 < phi < 1:
+                    hl = -log(2) / log(phi)
+                    res[sym] = float(hl) if np.isfinite(hl) else np.nan
+                else:
+                    res[sym] = np.nan
+            except Exception:
+                res[sym] = np.nan
+
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = VWAPDevAR1HalfLifeBarsFeature()

--- a/cube2mat/features/xcorr_n_absret_lag1.py
+++ b/cube2mat/features/xcorr_n_absret_lag1.py
@@ -1,0 +1,64 @@
+# features/xcorr_n_absret_lag1.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+class XCorrNAbsRetLag1Feature(BaseFeature):
+    """
+    Correlation between n_t and |logret_{t+1}| within RTH.
+    Returns NaN if fewer than 3 pairs or zero variance.
+    """
+
+    name = "xcorr_n_absret_lag1"
+    description = "Lead-lag corr: trades count leads |logret| by 1 bar."
+    required_full_columns = ("symbol", "time", "close", "n")
+    required_pv_columns = ("symbol",)
+
+    @staticmethod
+    def _corr(x: np.ndarray, y: np.ndarray) -> float:
+        if x.size != y.size or x.size < 3:
+            return np.nan
+        xc = x - x.mean()
+        yc = y - y.mean()
+        sx = float(np.sqrt(np.sum(xc * xc)))
+        sy = float(np.sqrt(np.sum(yc * yc)))
+        if sx <= 0 or sy <= 0 or not np.isfinite(sx * sy):
+            return np.nan
+        return float(np.sum(xc * yc) / (sx * sy))
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, ["symbol", "time", "close", "n"])
+        sample = self.load_pv(ctx, date, ["symbol"])
+        if df is None or sample is None:
+            return None
+
+        out = sample[["symbol"]].copy()
+        if df.empty or sample.empty:
+            out["value"] = pd.NA
+            return out
+
+        df = self.ensure_et_index(df, "time", ctx.tz).between_time("09:30", "15:59").copy()
+        for c in ("close", "n"):
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+        df = df.dropna(subset=["close", "n"])
+        df = df[df.symbol.isin(sample.symbol.unique())]
+        if df.empty:
+            out["value"] = pd.NA
+            return out
+
+        res: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", sort=False):
+            g = g.sort_index()
+            r = np.log(g["close"]).diff().abs()
+            y = r.shift(-1)
+            xy = pd.concat([g["n"], y], axis=1).dropna()
+            res[sym] = self._corr(xy.iloc[:, 0].to_numpy(), xy.iloc[:, 1].to_numpy())
+
+        out["value"] = out["symbol"].map(res)
+        return out
+
+
+feature = XCorrNAbsRetLag1Feature()


### PR DESCRIPTION
## Summary
- expand VWAP analytics with crossing counts, run lengths, mean premium, deviation beta, AR(1) half-life, and post-cross returns
- add entropy, run-length, and trade size stability measures
- introduce volume timing, volatility, and price-volume correlation features

## Testing
- `python -m py_compile cube2mat/features/vwap_cross_count.py cube2mat/features/vwap_avg_run_length_above.py cube2mat/features/ret_next_on_vwapdev_beta.py cube2mat/features/vwap_dev_ar1_halflife_bars.py cube2mat/features/entropy_sign_ret.py cube2mat/features/mean_run_length_sign.py cube2mat/features/cv_trade_size.py cube2mat/features/n_front_loading_score.py cube2mat/features/time_to_50pct_volume_min.py cube2mat/features/time_to_50pct_volume_frac.py cube2mat/features/ewma_rvol_logret_094.py cube2mat/features/accel_over_vel_std_ratio.py cube2mat/features/xcorr_n_absret_lag1.py cube2mat/features/range_on_logvolume_beta.py cube2mat/features/mean_close_vwap_rel_diff.py cube2mat/features/vwap_cross_up_nextret.py cube2mat/features/vwap_cross_down_nextret.py cube2mat/features/gini_absret.py cube2mat/features/corr_ret_n.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68a1f575cad8832aaebb6cd4b4bd7074