### PR TITLE
Add advanced intraday microstructure features

### DIFF
--- a/cube2mat/features/absret_on_sqrtn_beta.py
+++ b/cube2mat/features/absret_on_sqrtn_beta.py
@@ -1,0 +1,40 @@
+# features/absret_on_sqrtn_beta.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class AbsRetOnSqrtNBetaFeature(BaseFeature):
+    """
+    OLS slope of |logret| on sqrt(n) (aligned to return end bar). NaN if insufficient or var(sqrt(n))=0.
+    """
+    name = "absret_on_sqrtn_beta"
+    description = "Elasticity of |logret| to sqrt(n) per bar."
+    required_full_columns = ("symbol","time","close","n")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        cols=["symbol","time","close","n"]
+        df=self.load_full(ctx,date,cols); sample=self.load_pv(ctx,date,["symbol"])
+        if df is None or sample is None: return None
+        out=sample[["symbol"]].copy()
+        if df.empty or sample.empty: out["value"]=pd.NA; return out
+        df=self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59").copy()
+        for c in ("close","n"): df[c]=pd.to_numeric(df[c],errors="coerce")
+        df=df.dropna(subset=["close","n"])
+        df=df[df.symbol.isin(sample.symbol.unique())]
+        if df.empty: out["value"]=pd.NA; return out
+        res={}
+        for sym,g in df.groupby("symbol", sort=False):
+            g=g.sort_index()
+            r=np.log(g["close"]).diff().replace([np.inf,-np.inf],np.nan).abs()
+            x=g["n"].iloc[1:].pow(0.5)  # align to end bar
+            y=r.iloc[1:]
+            xy=pd.concat([x,y],axis=1).dropna()
+            if len(xy)<3 or xy.iloc[:,0].var()==0: res[sym]=np.nan; continue
+            X=np.column_stack([np.ones(len(xy)), xy.iloc[:,0].to_numpy()])
+            beta,_=np.linalg.lstsq(X, xy.iloc[:,1].to_numpy(), rcond=None)
+            res[sym]=float(beta[1])
+        out["value"]=out["symbol"].map(res); return out
+
+feature = AbsRetOnSqrtNBetaFeature()

--- a/cube2mat/features/bpv_to_rv_ratio.py
+++ b/cube2mat/features/bpv_to_rv_ratio.py
@@ -1,0 +1,38 @@
+# features/bpv_to_rv_ratio.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np,pandas as pd
+from math import pi
+from feature_base import BaseFeature, FeatureContext
+
+class BPVtoRVRatioFeature(BaseFeature):
+    """
+    Ratio of Bipower Variation to Realized Variance using log returns in RTH:
+      RV = sum r^2; BPV = (pi/2)*sum |r_t||r_{t-1}|.
+    NaN if <3 returns or RV<=0.
+    """
+    name = "bpv_to_rv_ratio"
+    description = "Bipower Variation relative to Realized Variance (log returns)."
+    required_full_columns = ("symbol","time","close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df=self.load_full(ctx,date,["symbol","time","close"])
+        sample=self.load_pv(ctx,date,["symbol"])
+        if df is None or sample is None:return None
+        out=sample[["symbol"]].copy()
+        if df.empty or sample.empty: out["value"]=pd.NA; return out
+        df=self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59").copy()
+        df=df[df.symbol.isin(sample.symbol.unique())]
+        df["close"]=pd.to_numeric(df["close"],errors="coerce"); df=df.dropna(subset=["close"])
+        if df.empty: out["value"]=pd.NA; return out
+        res={}
+        for sym,g in df.groupby("symbol",sort=False):
+            r=np.log(g.sort_index()["close"]).diff().replace([np.inf,-np.inf],np.nan).dropna()
+            if len(r)<3: res[sym]=np.nan; continue
+            RV=float((r*r).sum())
+            BPV=float((pi/2.0) * np.sum(np.abs(r.values[1:])*np.abs(r.values[:-1])))
+            res[sym]= (BPV/RV) if RV>0 else np.nan
+        out["value"]=out["symbol"].map(res); return out
+
+feature = BPVtoRVRatioFeature()

--- a/cube2mat/features/corr_ret_absnextret.py
+++ b/cube2mat/features/corr_ret_absnextret.py
@@ -1,0 +1,47 @@
+# features/corr_ret_absnextret.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np,pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class CorrRetAbsNextRetFeature(BaseFeature):
+    """
+    Pearson corr between simple ret_t and |simple ret_{t+1}| in RTH.
+    NaN if <3 pairs or zero variance.
+    """
+    name = "corr_ret_absnextret"
+    description = "Corr(ret_t, |ret_{t+1}|) leverage-effect proxy."
+    required_full_columns = ("symbol","time","close")
+    required_pv_columns = ("symbol",)
+
+    @staticmethod
+    def _corr(x: np.ndarray, y: np.ndarray) -> float:
+        if x.size!=y.size or x.size<3: return np.nan
+        xc=x-x.mean(); yc=y-y.mean()
+        sx=float(np.sqrt(np.sum(xc*xc))); sy=float(np.sqrt(np.sum(yc*yc)))
+        if sx<=0 or sy<=0 or not np.isfinite(sx*sy): return np.nan
+        return float(np.sum(xc*yc)/(sx*sy))
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df=self.load_full(ctx,date,["symbol","time","close"])
+        sample=self.load_pv(ctx,date,["symbol"])
+        if df is None or sample is None:return None
+        out=sample[["symbol"]].copy()
+        if df.empty or sample.empty: out["value"]=pd.NA; return out
+
+        df=self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59")
+        df=df[df.symbol.isin(sample.symbol.unique())].copy()
+        df["close"]=pd.to_numeric(df["close"],errors="coerce")
+        df=df.dropna(subset=["close"])
+        if df.empty: out["value"]=pd.NA; return out
+
+        res={}
+        for sym,g in df.groupby("symbol",sort=False):
+            r=g.sort_index()["close"].pct_change().replace([np.inf,-np.inf],np.nan)
+            x=r
+            y=r.shift(-1).abs()
+            xy=pd.concat([x,y],axis=1).dropna()
+            res[sym]=self._corr(xy.iloc[:,0].to_numpy(), xy.iloc[:,1].to_numpy())
+        out["value"]=out["symbol"].map(res); return out
+
+feature = CorrRetAbsNextRetFeature()

--- a/cube2mat/features/dc_count_bps_10.py
+++ b/cube2mat/features/dc_count_bps_10.py
@@ -1,0 +1,51 @@
+# features/dc_count_bps_10.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np,pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class DCCountBps10Feature(BaseFeature):
+    """
+    Directional-change count with threshold theta=10bp (0.001) on close.
+    Event when price reverses by >=theta from the last swing extreme. NaN if <2 closes.
+    """
+    name = "dc_count_bps_10"
+    description = "Directional-change event count at 10bp threshold."
+    required_full_columns = ("symbol","time","close")
+    required_pv_columns = ("symbol",)
+    theta = 1e-3  # 10 bps
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df=self.load_full(ctx,date,["symbol","time","close"])
+        sample=self.load_pv(ctx,date,["symbol"])
+        if df is None or sample is None:return None
+        out=sample[["symbol"]].copy()
+        if df.empty or sample.empty: out["value"]=pd.NA; return out
+
+        df=self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59")
+        df=df[df.symbol.isin(sample.symbol.unique())]
+        df["close"]=pd.to_numeric(df["close"],errors="coerce")
+        df=df.dropna(subset=["close"])
+        if df.empty: out["value"]=pd.NA; return out
+
+        th=float(self.theta); res={}
+        for sym,g in df.groupby("symbol",sort=False):
+            p=g.sort_index()["close"].to_numpy(float)
+            n=p.size
+            if n<2: res[sym]=np.nan; continue
+            count=0; dir=0
+            extreme=p[0]; ref=p[0]
+            for px in p[1:]:
+                if dir==0:
+                    if px>=ref*(1+th): dir=+1; extreme=px; count+=1
+                    elif px<=ref*(1-th): dir=-1; extreme=px; count+=1
+                elif dir==+1:
+                    if px>extreme: extreme=px
+                    elif px<=extreme*(1-th): dir=-1; extreme=px; count+=1
+                else:
+                    if px<extreme: extreme=px
+                    elif px>=extreme*(1+th): dir=+1; extreme=px; count+=1
+            res[sym]=float(count)
+        out["value"]=out["symbol"].map(res); return out
+
+feature = DCCountBps10Feature()

--- a/cube2mat/features/duration_since_last_vwap_cross_frac.py
+++ b/cube2mat/features/duration_since_last_vwap_cross_frac.py
@@ -1,0 +1,46 @@
+# features/duration_since_last_vwap_cross_frac.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np,pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+TOT_MIN = 389.0
+
+class DurationSinceLastVWAPCrossFracFeature(BaseFeature):
+    """
+    Fraction of session elapsed since the last strict cross of (close-vwap) sign.
+    If no cross in RTH, returns NaN.
+    """
+    name = "duration_since_last_vwap_cross_frac"
+    description = "Session fraction since last VWAP crossing (stickiness)."
+    required_full_columns = ("symbol","time","close","vwap")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        cols=["symbol","time","close","vwap"]
+        df=self.load_full(ctx,date,cols); sample=self.load_pv(ctx,date,["symbol"])
+        if df is None or sample is None:return None
+        out=sample[["symbol"]].copy()
+        if df.empty or sample.empty: out["value"]=pd.NA; return out
+
+        df=self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59")
+        for c in ("close","vwap"): df[c]=pd.to_numeric(df[c],errors="coerce")
+        df=df.dropna(subset=["close","vwap"])
+        df=df[df.symbol.isin(sample.symbol.unique())]
+        if df.empty: out["value"]=pd.NA; return out
+
+        res={}
+        for sym,g in df.groupby("symbol",sort=False):
+            g=g.sort_index()
+            d=(g["close"]-g["vwap"]).to_numpy(float)
+            if d.size<2: res[sym]=np.nan; continue
+            s=np.sign(d)
+            cross_idx=np.where(s[1:]*s[:-1] < 0)[0]
+            if cross_idx.size==0:
+                res[sym]=np.nan; continue
+            last_cross_time=g.index[cross_idx[-1]+1]
+            frac=float((g.index[-1]-last_cross_time).total_seconds()/60.0)/TOT_MIN
+            res[sym]=float(np.clip(frac,0.0,1.0))
+        out["value"]=out["symbol"].map(res); return out
+
+feature = DurationSinceLastVWAPCrossFracFeature()

--- a/cube2mat/features/impact_slope_price_cumn.py
+++ b/cube2mat/features/impact_slope_price_cumn.py
@@ -1,0 +1,43 @@
+# features/impact_slope_price_cumn.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np,pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class ImpactSlopePriceCumNFeature(BaseFeature):
+    """
+    OLS slope of (close - first_open) on cumulative trade count within RTH.
+    NaN if insufficient or var(cum_n)=0.
+    """
+    name = "impact_slope_price_cumn"
+    description = "OLS beta of (close - first_open) on cumulative n (RTH)."
+    required_full_columns = ("symbol","time","open","close","n")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        cols=["symbol","time","open","close","n"]
+        df=self.load_full(ctx,date,cols); sample=self.load_pv(ctx,date,["symbol"])
+        if df is None or sample is None:return None
+        out=sample[["symbol"]].copy()
+        if df.empty or sample.empty: out["value"]=pd.NA; return out
+
+        df=self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59").copy()
+        for c in ("open","close","n"): df[c]=pd.to_numeric(df[c],errors="coerce")
+        df=df.dropna(subset=["close","n"])
+        df=df[df.symbol.isin(sample.symbol.unique())]
+        if df.empty: out["value"]=pd.NA; return out
+        res={}
+        for sym,g in df.groupby("symbol",sort=False):
+            g=g.sort_index()
+            if g["open"].dropna().empty or len(g)<2: res[sym]=np.nan; continue
+            anchor=float(g["open"].dropna().iloc[0])
+            y=(g["close"]-anchor)
+            x=g["n"].cumsum()
+            xy=pd.concat([x,y],axis=1).dropna()
+            if len(xy)<3 or xy.iloc[:,0].var()==0: res[sym]=np.nan; continue
+            X=np.column_stack([np.ones(len(xy)), xy.iloc[:,0].to_numpy()])
+            beta,_=np.linalg.lstsq(X, xy.iloc[:,1].to_numpy(), rcond=None)
+            res[sym]=float(beta[1])
+        out["value"]=out["symbol"].map(res); return out
+
+feature = ImpactSlopePriceCumNFeature()

--- a/cube2mat/features/kyle_lambda_lead1_beta.py
+++ b/cube2mat/features/kyle_lambda_lead1_beta.py
@@ -1,0 +1,42 @@
+# features/kyle_lambda_lead1_beta.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class KyleLambdaLead1BetaFeature(BaseFeature):
+    """
+    OLS slope (beta) of next simple return on signed volume proxy:
+      x_t = sign(ret_t) * volume_t, y_t = ret_{t+1}.
+    Reduces endogeneity vs contemporaneous spec. NaN if insufficient.
+    """
+    name = "kyle_lambda_lead1_beta"
+    description = "Beta of ret_{t+1} on sign(ret_t)*volume_t (Kyle λ proxy)."
+    required_full_columns = ("symbol","time","close","volume")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        cols=["symbol","time","close","volume"]
+        df=self.load_full(ctx,date,cols); sample=self.load_pv(ctx,date,["symbol"])
+        if df is None or sample is None: return None
+        out=sample[["symbol"]].copy()
+        if df.empty or sample.empty: out["value"]=pd.NA; return out
+        df=self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59").copy()
+        for c in ("close","volume"): df[c]=pd.to_numeric(df[c],errors="coerce")
+        df=df.dropna(subset=["close","volume"])
+        df=df[df.symbol.isin(sample.symbol.unique())]
+        if df.empty: out["value"]=pd.NA; return out
+        res={}
+        for sym,g in df.groupby("symbol",sort=False):
+            g=g.sort_index()
+            r=g["close"].pct_change()
+            x=np.sign(r)*g["volume"]
+            y=r.shift(-1)
+            xy=pd.concat([x,y],axis=1).dropna()
+            if len(xy)<3 or xy.iloc[:,0].var()==0: res[sym]=np.nan; continue
+            X=np.column_stack([np.ones(len(xy)), xy.iloc[:,0].to_numpy()])
+            beta,_=np.linalg.lstsq(X, xy.iloc[:,1].to_numpy(), rcond=None)
+            res[sym]=float(beta[1])
+        out["value"]=out["symbol"].map(res); return out
+
+feature = KyleLambdaLead1BetaFeature()

--- a/cube2mat/features/log_absret_on_logvolume_beta.py
+++ b/cube2mat/features/log_absret_on_logvolume_beta.py
@@ -1,0 +1,43 @@
+# features/log_absret_on_logvolume_beta.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class LogAbsRetOnLogVolumeBetaFeature(BaseFeature):
+    """
+    Price-impact power law: OLS slope of log(|logret|) on log(volume) in RTH.
+    Drop bars where |logret|<=0 or volume<=0. NaN if insufficient or var(logV)=0.
+    """
+    name = "log_absret_on_logvolume_beta"
+    description = "Impact exponent: slope of log|logret| ~ log(volume)."
+    required_full_columns = ("symbol","time","close","volume")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        cols=["symbol","time","close","volume"]
+        df=self.load_full(ctx,date,cols); sample=self.load_pv(ctx,date,["symbol"])
+        if df is None or sample is None: return None
+        out=sample[["symbol"]].copy()
+        if df.empty or sample.empty: out["value"]=pd.NA; return out
+
+        df=self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59")
+        for c in ("close","volume"): df[c]=pd.to_numeric(df[c],errors="coerce")
+        df=df.dropna(subset=["close","volume"])
+        df=df[df.symbol.isin(sample.symbol.unique())]
+        if df.empty: out["value"]=pd.NA; return out
+
+        res={}
+        for sym,g in df.groupby("symbol", sort=False):
+            g=g.sort_index()
+            r=np.log(g["close"]).diff().replace([np.inf,-np.inf],np.nan).abs()
+            x=np.log(g["volume"].replace(0,np.nan))
+            y=np.log(r.replace(0,np.nan))
+            xy=pd.concat([x,y],axis=1).dropna()
+            if len(xy)<3 or xy.iloc[:,0].var()==0: res[sym]=np.nan; continue
+            X=np.column_stack([np.ones(len(xy)), xy.iloc[:,0].to_numpy()])
+            beta,_=np.linalg.lstsq(X, xy.iloc[:,1].to_numpy(), rcond=None)
+            res[sym]=float(beta[1])
+        out["value"]=out["symbol"].map(res); return out
+
+feature = LogAbsRetOnLogVolumeBetaFeature()

--- a/cube2mat/features/midday_lull_rv_ratio.py
+++ b/cube2mat/features/midday_lull_rv_ratio.py
@@ -1,0 +1,48 @@
+# features/midday_lull_rv_ratio.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np,pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class MiddayLullRVRatioFeature(BaseFeature):
+    """
+    RV density ratio at midday (12:00–12:59):
+      ratio = (sum r^2_mid / sum r^2_total) / (count_ret_mid / count_ret_total).
+    NaN if RV_total<=0 or insufficient returns.
+    """
+    name = "midday_lull_rv_ratio"
+    description = "RV density at midday vs session average."
+    required_full_columns = ("symbol","time","close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        cols=["symbol","time","close"]
+        df=self.load_full(ctx,date,cols); sample=self.load_pv(ctx,date,["symbol"])
+        if df is None or sample is None:return None
+        out=sample[["symbol"]].copy()
+        if df.empty or sample.empty: out["value"]=pd.NA; return out
+
+        df=self.ensure_et_index(df,"time",ctx.tz)
+        rth=df.between_time("09:30","15:59")
+        rth=rth[rth.symbol.isin(sample.symbol.unique())].copy()
+        rth["close"]=pd.to_numeric(rth["close"],errors="coerce"); rth=rth.dropna(subset=["close"])
+        if rth.empty: out["value"]=pd.NA; return out
+
+        mid=rth.between_time("12:00","12:59")
+        res={}
+        for sym,g in rth.groupby("symbol",sort=False):
+            g=g.sort_index()
+            r=np.log(g["close"]).diff().replace([np.inf,-np.inf],np.nan)
+            total=float((r.dropna()**2).sum()); cnt_total=int(r.dropna().shape[0])
+            m=mid[mid.symbol==sym].sort_index()
+            if m.empty or cnt_total<3 or total<=0:
+                res[sym]=np.nan; continue
+            r.index=g.index[1:]
+            rv_mid=float((r[r.index.isin(m.index)]**2).sum())
+            cnt_mid=int(r.index.isin(m.index).sum())
+            if cnt_mid==0: res[sym]=np.nan; continue
+            ratio=(rv_mid/total)/ (cnt_mid/max(1,cnt_total))
+            res[sym]=float(ratio)
+        out["value"]=out["symbol"].map(res); return out
+
+feature = MiddayLullRVRatioFeature()

--- a/cube2mat/features/n_gini.py
+++ b/cube2mat/features/n_gini.py
@@ -1,0 +1,39 @@
+# features/n_gini.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np,pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+def _gini(x: np.ndarray) -> float:
+    x=np.asarray(x,float); x=x[np.isfinite(x)&(x>=0)]
+    n=x.size; s=x.sum()
+    if n<2 or s<=0: return np.nan
+    xs=np.sort(x); i=np.arange(1,n+1)
+    g=1.0 - 2.0*np.sum((n - i + 0.5)*xs)/(n*s)
+    return float(np.clip(g,0.0,1.0))
+
+class NGiniFeature(BaseFeature):
+    """
+    Gini index of trade count distribution across RTH bars.
+    """
+    name = "n_gini"
+    description = "Gini of per-bar trade counts (n) in RTH."
+    required_full_columns = ("symbol","time","n")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df=self.load_full(ctx,date,["symbol","time","n"])
+        sample=self.load_pv(ctx,date,["symbol"])
+        if df is None or sample is None:return None
+        out=sample[["symbol"]].copy()
+        if df.empty or sample.empty: out["value"]=pd.NA; return out
+
+        df=self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59")
+        df=df[df.symbol.isin(sample.symbol.unique())]
+        df["n"]=pd.to_numeric(df["n"],errors="coerce"); df=df.dropna(subset=["n"])
+        if df.empty: out["value"]=pd.NA; return out
+
+        res=df.groupby("symbol")["n"].apply(lambda s: _gini(s.values))
+        out["value"]=out["symbol"].map(res); return out
+
+feature = NGiniFeature()

--- a/cube2mat/features/near_close_ramp_slope_10m.py
+++ b/cube2mat/features/near_close_ramp_slope_10m.py
@@ -1,0 +1,39 @@
+# features/near_close_ramp_slope_10m.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np,pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class NearCloseRampSlope10mFeature(BaseFeature):
+    """
+    OLS slope of close on minutes since 15:50 within 15:50–15:59 window.
+    NaN if <2 points or var(time)=0.
+    """
+    name = "near_close_ramp_slope_10m"
+    description = "Tail 10-minute linear slope of close vs time."
+    required_full_columns = ("symbol","time","close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df=self.load_full(ctx,date,["symbol","time","close"])
+        sample=self.load_pv(ctx,date,["symbol"])
+        if df is None or sample is None:return None
+        out=sample[["symbol"]].copy()
+        if df.empty or sample.empty: out["value"]=pd.NA; return out
+        df=self.ensure_et_index(df,"time",ctx.tz)
+        win=df.between_time("15:50","15:59").copy()
+        for c in ("close",): win[c]=pd.to_numeric(win[c],errors="coerce")
+        win=win.dropna(subset=["close"])
+        win=win[win.symbol.isin(sample.symbol.unique())]
+        if win.empty: out["value"]=pd.NA; return out
+        res={}
+        for sym,g in win.groupby("symbol",sort=False):
+            g=g.sort_index()
+            if len(g)<2: res[sym]=np.nan; continue
+            t=(g.index - g.index[0]).total_seconds()/60.0
+            X=np.column_stack([np.ones(len(g)), t.to_numpy()])
+            beta,_=np.linalg.lstsq(X, g["close"].to_numpy(float), rcond=None)
+            res[sym]=float(beta[1])
+        out["value"]=out["symbol"].map(res); return out
+
+feature = NearCloseRampSlope10mFeature()

--- a/cube2mat/features/next_absret_after_top_vol_decile.py
+++ b/cube2mat/features/next_absret_after_top_vol_decile.py
@@ -1,0 +1,38 @@
+# features/next_absret_after_top_vol_decile.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np,pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class NextAbsRetAfterTopVolDecileFeature(BaseFeature):
+    """
+    Mean of |logret_{t+1}| conditional on volume_t in top 10% within RTH.
+    NaN if <3 events.
+    """
+    name = "next_absret_after_top_vol_decile"
+    description = "E[|logret_{t+1}| | volume_t in top decile]."
+    required_full_columns = ("symbol","time","close","volume")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        cols=["symbol","time","close","volume"]
+        df=self.load_full(ctx,date,cols); sample=self.load_pv(ctx,date,["symbol"])
+        if df is None or sample is None:return None
+        out=sample[["symbol"]].copy()
+        if df.empty or sample.empty: out["value"]=pd.NA; return out
+
+        df=self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59")
+        for c in ("close","volume"): df[c]=pd.to_numeric(df[c],errors="coerce")
+        df=df.dropna(subset=["close","volume"])
+        df=df[df.symbol.isin(sample.symbol.unique())]
+        if df.empty: out["value"]=pd.NA; return out
+        res={}
+        for sym,g in df.groupby("symbol",sort=False):
+            g=g.sort_index()
+            thr=float(g["volume"].quantile(0.9))
+            nxt=np.log(g["close"]).diff().abs().shift(-1)
+            vals=nxt[g["volume"]>=thr].dropna()
+            res[sym]=float(vals.mean()) if len(vals)>=3 else np.nan
+        out["value"]=out["symbol"].map(res); return out
+
+feature = NextAbsRetAfterTopVolDecileFeature()

--- a/cube2mat/features/next_ret_after_top_absret_decile.py
+++ b/cube2mat/features/next_ret_after_top_absret_decile.py
@@ -1,0 +1,38 @@
+# features/next_ret_after_top_absret_decile.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np,pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class NextRetAfterTopAbsRetDecileFeature(BaseFeature):
+    """
+    Mean of next simple return conditional on current |logret| in top 10% within RTH.
+    NaN if <3 events.
+    """
+    name = "next_ret_after_top_absret_decile"
+    description = "E[ret_{t+1} | |logret_t| in top decile]."
+    required_full_columns = ("symbol","time","close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        cols=["symbol","time","close"]
+        df=self.load_full(ctx,date,cols); sample=self.load_pv(ctx,date,["symbol"])
+        if df is None or sample is None:return None
+        out=sample[["symbol"]].copy()
+        if df.empty or sample.empty: out["value"]=pd.NA; return out
+        df=self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59")
+        df=df[df.symbol.isin(sample.symbol.unique())].copy()
+        df["close"]=pd.to_numeric(df["close"],errors="coerce")
+        df=df.dropna(subset=["close"])
+        if df.empty: out["value"]=pd.NA; return out
+        res={}
+        for sym,g in df.groupby("symbol",sort=False):
+            g=g.sort_index()
+            a=np.log(g["close"]).diff().abs()
+            thr=float(a.quantile(0.9))
+            nxt=g["close"].pct_change().shift(-1)
+            vals=nxt[a>=thr].dropna()
+            res[sym]=float(vals.mean()) if len(vals)>=3 else np.nan
+        out["value"]=out["symbol"].map(res); return out
+
+feature = NextRetAfterTopAbsRetDecileFeature()

--- a/cube2mat/features/oc_return_last30m_share.py
+++ b/cube2mat/features/oc_return_last30m_share.py
@@ -1,0 +1,42 @@
+# features/oc_return_last30m_share.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np,pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class OCReturnLast30mShareFeature(BaseFeature):
+    """
+    Share of net RTH log return contributed by last 30 minutes (15:30–15:59):
+      share = sum r_tail / sum r_all. NaN if denominator==0 or insufficient.
+    """
+    name = "oc_return_last30m_share"
+    description = "Net-return share from last 30 minutes of RTH."
+    required_full_columns = ("symbol","time","close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        cols=["symbol","time","close"]
+        df=self.load_full(ctx,date,cols); sample=self.load_pv(ctx,date,["symbol"])
+        if df is None or sample is None:return None
+        out=sample[["symbol"]].copy()
+
+        df=self.ensure_et_index(df,"time",ctx.tz)
+        rth=df.between_time("09:30","15:59")
+        tail=df.between_time("15:30","15:59")
+        rth=rth[rth.symbol.isin(sample.symbol.unique())].copy()
+        for c in ("close",): rth[c]=pd.to_numeric(rth[c],errors="coerce")
+        rth=rth.dropna(subset=["close"])
+        if rth.empty: out["value"]=pd.NA; return out
+        res={}
+        for sym,g in rth.groupby("symbol",sort=False):
+            g=g.sort_index()
+            r=np.log(g["close"]).diff().replace([np.inf,-np.inf],np.nan).dropna()
+            if r.empty: res[sym]=np.nan; continue
+            total=float(r.sum())
+            if total==0: res[sym]=np.nan; continue
+            r.index=g.index[1:]
+            part=r[r.index.isin(tail.index)]
+            res[sym]=float(part.sum()/total) if not part.empty else np.nan
+        out["value"]=out["symbol"].map(res); return out
+
+feature = OCReturnLast30mShareFeature()

--- a/cube2mat/features/path_length_over_range.py
+++ b/cube2mat/features/path_length_over_range.py
@@ -1,0 +1,40 @@
+# features/path_length_over_range.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np,pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class PathLengthOverRangeFeature(BaseFeature):
+    """
+    Path choppiness ratio: sum(|Δclose|) / (max(high)-min(low)) within RTH.
+    NaN if <2 closes or range<=0.
+    """
+    name = "path_length_over_range"
+    description = "Sum|Δclose| normalized by session range (H-L)."
+    required_full_columns = ("symbol","time","high","low","close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        cols=["symbol","time","high","low","close"]
+        df=self.load_full(ctx,date,cols); sample=self.load_pv(ctx,date,["symbol"])
+        if df is None or sample is None:return None
+        out=sample[["symbol"]].copy()
+        if df.empty or sample.empty: out["value"]=pd.NA; return out
+        df=self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59").copy()
+        for c in ("high","low","close"): df[c]=pd.to_numeric(df[c],errors="coerce")
+        df=df.dropna(subset=["high","low","close"])
+        df=df[df.symbol.isin(sample.symbol.unique())]
+        if df.empty: out["value"]=pd.NA; return out
+
+        res={}
+        for sym,g in df.groupby("symbol",sort=False):
+            g=g.sort_index()
+            c=g["close"].to_numpy(float)
+            if c.size<2: res[sym]=np.nan; continue
+            path=float(np.abs(np.diff(c)).sum())
+            H=float(g["high"].max()); L=float(g["low"].min())
+            rng=H-L
+            res[sym]= path/rng if rng>0 else np.nan
+        out["value"]=out["symbol"].map(res); return out
+
+feature = PathLengthOverRangeFeature()

--- a/cube2mat/features/rvol_over_sqrt_trades.py
+++ b/cube2mat/features/rvol_over_sqrt_trades.py
@@ -1,0 +1,38 @@
+# features/rvol_over_sqrt_trades.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class RVolOverSqrtTradesFeature(BaseFeature):
+    """
+    Invariance proxy: sqrt( sum r^2 ) / sqrt( sum n ), r=log returns in RTH.
+    NaN if RV<=0 or sum(n)<=0 or <3 returns.
+    """
+    name = "rvol_over_sqrt_trades"
+    description = "sqrt(RV)/sqrt(total trades) invariance proxy (RTH)."
+    required_full_columns = ("symbol","time","close","n")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df=self.load_full(ctx,date,["symbol","time","close","n"])
+        sample=self.load_pv(ctx,date,["symbol"])
+        if df is None or sample is None:return None
+        out=sample[["symbol"]].copy()
+        if df.empty or sample.empty: out["value"]=pd.NA; return out
+        df=self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59")
+        for c in ("close","n"): df[c]=pd.to_numeric(df[c],errors="coerce")
+        df=df.dropna(subset=["close","n"])
+        df=df[df.symbol.isin(sample.symbol.unique())]
+        if df.empty: out["value"]=pd.NA; return out
+        res={}
+        for sym,g in df.groupby("symbol",sort=False):
+            g=g.sort_index()
+            r=np.log(g["close"]).diff().replace([np.inf,-np.inf],np.nan).dropna()
+            if len(r)<3: res[sym]=np.nan; continue
+            RV=float((r*r).sum()); TN=float(g["n"].sum())
+            if RV<=0 or TN<=0: res[sym]=np.nan; continue
+            res[sym]=float(np.sqrt(RV)/np.sqrt(TN))
+        out["value"]=out["symbol"].map(res); return out
+
+feature = RVolOverSqrtTradesFeature()

--- a/cube2mat/features/signed_volume_imbalance.py
+++ b/cube2mat/features/signed_volume_imbalance.py
@@ -1,0 +1,40 @@
+# features/signed_volume_imbalance.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np,pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class SignedVolumeImbalanceFeature(BaseFeature):
+    """
+    Net signed volume fraction using tick-rule proxy:
+      value = sum(sign(simple ret)*volume) / sum(volume) in RTH.
+    NaN if total volume<=0 or <1 return.
+    """
+    name = "signed_volume_imbalance"
+    description = "Signed volume share ∈ [-1,1] based on ret sign proxy."
+    required_full_columns = ("symbol","time","close","volume")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        cols=["symbol","time","close","volume"]
+        df=self.load_full(ctx,date,cols); sample=self.load_pv(ctx,date,["symbol"])
+        if df is None or sample is None:return None
+        out=sample[["symbol"]].copy()
+        if df.empty or sample.empty: out["value"]=pd.NA; return out
+        df=self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59").copy()
+        for c in ("close","volume"): df[c]=pd.to_numeric(df[c],errors="coerce")
+        df=df.dropna(subset=["close","volume"])
+        df=df[df.symbol.isin(sample.symbol.unique())]
+        if df.empty: out["value"]=pd.NA; return out
+        res={}
+        for sym,g in df.groupby("symbol",sort=False):
+            g=g.sort_index()
+            r=g["close"].pct_change().replace([np.inf,-np.inf],np.nan)
+            if r.dropna().empty: res[sym]=np.nan; continue
+            s=np.sign(r)
+            s=s.fillna(0.0)
+            num=float((s*g["volume"]).sum()); den=float(g["volume"].sum())
+            res[sym]= (num/den) if den>0 else np.nan
+        out["value"]=out["symbol"].map(res); return out
+
+feature = SignedVolumeImbalanceFeature()

--- a/cube2mat/features/std_vwap_dev_rel.py
+++ b/cube2mat/features/std_vwap_dev_rel.py
@@ -1,0 +1,35 @@
+# features/std_vwap_dev_rel.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np,pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class StdVWAPDevRelFeature(BaseFeature):
+    """
+    Standard deviation of relative deviation (close - vwap)/vwap within RTH.
+    NaN if <2 bars or any vwap<=0.
+    """
+    name = "std_vwap_dev_rel"
+    description = "Std of (close-vwap)/vwap across RTH bars."
+    required_full_columns = ("symbol","time","close","vwap")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        cols=["symbol","time","close","vwap"]
+        df=self.load_full(ctx,date,cols); sample=self.load_pv(ctx,date,["symbol"])
+        if df is None or sample is None:return None
+        out=sample[["symbol"]].copy()
+        if df.empty or sample.empty: out["value"]=pd.NA; return out
+
+        df=self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59")
+        for c in ("close","vwap"): df[c]=pd.to_numeric(df[c],errors="coerce")
+        df=df.dropna(subset=["close","vwap"])
+        df=df[df["vwap"]>0]
+        df=df[df.symbol.isin(sample.symbol.unique())]
+        if df.empty: out["value"]=pd.NA; return out
+        res=df.assign(z=(df["close"]-df["vwap"])/df["vwap"]).groupby("symbol")["z"].apply(
+            lambda s: float(s.std(ddof=1)) if len(s)>=2 else np.nan
+        )
+        out["value"]=out["symbol"].map(res); return out
+
+feature = StdVWAPDevRelFeature()

--- a/cube2mat/features/theil_sen_slope_close_time.py
+++ b/cube2mat/features/theil_sen_slope_close_time.py
@@ -1,0 +1,49 @@
+# features/theil_sen_slope_close_time.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np,pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class TheilSenSlopeCloseTimeFeature(BaseFeature):
+    """
+    Theil–Sen robust slope of close on minutes since 09:30 within RTH.
+    Median of pairwise slopes (y_j - y_i)/(t_j - t_i), i<j. NaN if <2 points.
+    """
+    name = "theil_sen_slope_close_time"
+    description = "Robust trend slope (Theil–Sen) of close vs time (minutes)."
+    required_full_columns = ("symbol","time","close")
+    required_pv_columns = ("symbol",)
+
+    def _theil_sen(self, t: np.ndarray, y: np.ndarray) -> float:
+        n=y.size
+        if n<2: return np.nan
+        slopes=[]
+        for i in range(n-1):
+            dt=t[i+1:]-t[i]
+            dy=y[i+1:]-y[i]
+            m=dy[dt!=0]/dt[dt!=0]
+            if m.size>0: slopes.append(m)
+        if not slopes: return np.nan
+        allm=np.concatenate(slopes)
+        return float(np.median(allm))
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df=self.load_full(ctx,date,["symbol","time","close"])
+        sample=self.load_pv(ctx,date,["symbol"])
+        if df is None or sample is None:return None
+        out=sample[["symbol"]].copy()
+        if df.empty or sample.empty: out["value"]=pd.NA; return out
+        df=self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59").copy()
+        df=df[df.symbol.isin(sample.symbol.unique())]
+        df["close"]=pd.to_numeric(df["close"],errors="coerce"); df=df.dropna(subset=["close"])
+        if df.empty: out["value"]=pd.NA; return out
+
+        res={}
+        for sym,g in df.groupby("symbol",sort=False):
+            g=g.sort_index()
+            t=((g.index - g.index[0]).total_seconds()/60.0).to_numpy(float)
+            y=g["close"].to_numpy(float)
+            res[sym]=self._theil_sen(t,y)
+        out["value"]=out["symbol"].map(res); return out
+
+feature = TheilSenSlopeCloseTimeFeature()

--- a/cube2mat/features/volume_skew.py
+++ b/cube2mat/features/volume_skew.py
@@ -1,0 +1,39 @@
+# features/volume_skew.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np,pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class VolumeSkewFeature(BaseFeature):
+    """
+    Sample skewness of per-bar volume within RTH:
+      g1 = m3 / s^3 (Fisher). NaN if <3 bars or s==0.
+    """
+    name = "volume_skew"
+    description = "Skewness of volume distribution across RTH bars."
+    required_full_columns = ("symbol","time","volume")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df=self.load_full(ctx,date,["symbol","time","volume"])
+        sample=self.load_pv(ctx,date,["symbol"])
+        if df is None or sample is None:return None
+        out=sample[["symbol"]].copy()
+        if df.empty or sample.empty: out["value"]=pd.NA; return out
+
+        df=self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59")
+        df=df[df.symbol.isin(sample.symbol.unique())]
+        df["volume"]=pd.to_numeric(df["volume"],errors="coerce"); df=df.dropna(subset=["volume"])
+        if df.empty: out["value"]=pd.NA; return out
+        res={}
+        for sym,g in df.groupby("symbol",sort=False):
+            v=g.sort_index()["volume"].to_numpy(float)
+            n=v.size
+            if n<3: res[sym]=np.nan; continue
+            mu=v.mean(); s=v.std(ddof=1)
+            if s<=0: res[sym]=np.nan; continue
+            m3=float(np.mean((v-mu)**3))
+            res[sym]=float(m3/(s**3))
+        out["value"]=out["symbol"].map(res); return out
+
+feature = VolumeSkewFeature()

--- a/cube2mat/features/vwap_dev_bps_time_share_10bp.py
+++ b/cube2mat/features/vwap_dev_bps_time_share_10bp.py
@@ -1,0 +1,34 @@
+# features/vwap_dev_bps_time_share_10bp.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np,pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+class VWAPDevBPSTimeShare10bpFeature(BaseFeature):
+    """
+    Fraction of bars with |close - vwap| / vwap >= 10bp (0.001) within RTH.
+    """
+    name = "vwap_dev_bps_time_share_10bp"
+    description = "Time share with |close-vwap|/vwap >= 10bp."
+    required_full_columns = ("symbol","time","close","vwap")
+    required_pv_columns = ("symbol",)
+    thr = 1e-3  # 10 bps
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        cols=["symbol","time","close","vwap"]
+        df=self.load_full(ctx,date,cols); sample=self.load_pv(ctx,date,["symbol"])
+        if df is None or sample is None:return None
+        out=sample[["symbol"]].copy()
+        if df.empty or sample.empty: out["value"]=pd.NA; return out
+        df=self.ensure_et_index(df,"time",ctx.tz).between_time("09:30","15:59").copy()
+        for c in ("close","vwap"): df[c]=pd.to_numeric(df[c],errors="coerce")
+        df=df.dropna(subset=["close","vwap"])
+        df=df[df.symbol.isin(sample.symbol.unique())]
+        if df.empty: out["value"]=pd.NA; return out
+        thr=float(self.thr)
+        res=df.assign(dev=((df["close"]-df["vwap"]).abs()/df["vwap"])).groupby("symbol")["dev"].apply(
+            lambda s: float((s>=thr).mean()) if len(s)>0 else np.nan
+        )
+        out["value"]=out["symbol"].map(res); return out
+
+feature = VWAPDevBPSTimeShare10bpFeature()


### PR DESCRIPTION
## Summary
- add price-impact and liquidity metrics (Kyle lambda lead beta, log volume impact, sqrt trade elasticity, invariance ratio, cumulative trade impact, volume imbalance)
- add intraday seasonality and VWAP deviation features
- add path geometry, event-response, robust trend and distribution measures

## Testing
- `python -m py_compile cube2mat/features/*.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas'; attempted `pip install pandas` but proxy blocked download)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f899a0a8832a9ad6451effdc4225