### PR TITLE
Add additional intraday analytics features

### DIFF
--- a/cube2mat/features/candle_body_to_range_mean.py
+++ b/cube2mat/features/candle_body_to_range_mean.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+def _rth(df): return df.between_time("09:30","15:59")
+
+class CandleBodyToRangeMean(BaseFeature):
+    name = "candle_body_to_range_mean"
+    description = "Mean of |close-open|/(high-low) across RTH bars (exclude zero-range bars)."
+    required_full_columns = ("symbol","time","open","high","low","close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx,date,columns=list(self.required_full_columns))
+        pv = self.load_pv(ctx,date,columns=["symbol"])
+        if df is None or pv is None: return None
+        df = self.ensure_et_index(df, time_col="time", tz=ctx.tz)
+
+        out={}
+        for sym,g in df.groupby("symbol", observed=True):
+            try:
+                d = _rth(g)[["open","high","low","close"]].dropna().astype(float)
+                rng = (d["high"] - d["low"]).replace(0.0, np.nan)
+                ratio = np.abs(d["close"] - d["open"]) / rng
+                out[sym] = float(np.nanmean(ratio.values)) if ratio.size>0 else float("nan")
+            except Exception:
+                out[sym]=float("nan")
+        res = pv[["symbol"]].copy(); res["value"] = res["symbol"].map(out); return res
+
+feature = CandleBodyToRangeMean()

--- a/cube2mat/features/corr_signret_volume.py
+++ b/cube2mat/features/corr_signret_volume.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+def _rth(df): return df.between_time("09:30","15:59")
+def _logret(s): return np.log(s.astype(float)).diff()
+
+def _safe_corr(a: pd.Series, b: pd.Series) -> float:
+    a = pd.Series(a).astype(float); b = pd.Series(b).astype(float)
+    mask = a.notna() & b.notna()
+    if mask.sum() < 2: return float("nan")
+    return float(np.corrcoef(a[mask].values, b[mask].values)[0,1])
+
+class CorrSignRetVolume(BaseFeature):
+    name = "corr_signret_volume"
+    description = "Pearson correlation between sign(log-return) and volume within RTH (lag 0)."
+    required_full_columns = ("symbol","time","close","volume")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx,date,columns=list(self.required_full_columns))
+        pv = self.load_pv(ctx,date,columns=["symbol"])
+        if df is None or pv is None: return None
+        df = self.ensure_et_index(df, time_col="time", tz=ctx.tz)
+
+        out={}
+        for sym,g in df.groupby("symbol", observed=True):
+            try:
+                gg = _rth(g)[["close","volume"]].dropna()
+                r = _logret(gg["close"]).dropna()
+                vol = gg["volume"].astype(float).reindex(r.index)
+                out[sym] = _safe_corr(np.sign(r), vol)
+            except Exception:
+                out[sym]=float("nan")
+        res = pv[["symbol"]].copy(); res["value"] = res["symbol"].map(out); return res
+
+feature = CorrSignRetVolume()

--- a/cube2mat/features/ema20_trend_align_share.py
+++ b/cube2mat/features/ema20_trend_align_share.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+def _rth(df): return df.between_time("09:30","15:59")
+
+class EMA20TrendAlignShare(BaseFeature):
+    name = "ema20_trend_align_share"
+    description = "Share of RTH bars where sign(Δclose) == sign(ΔEMA20(close)); zeros ignored."
+    required_full_columns = ("symbol","time","close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx,date,columns=list(self.required_full_columns))
+        pv = self.load_pv(ctx,date,columns=["symbol"])
+        if df is None or pv is None: return None
+        df = self.ensure_et_index(df, time_col="time", tz=ctx.tz)
+
+        out={}
+        for sym,g in df.groupby("symbol", observed=True):
+            try:
+                s = _rth(g)["close"].astype(float).dropna()
+                if s.size < 3: out[sym]=float("nan"); continue
+                ema = s.ewm(span=20, adjust=False).mean()
+                sc = np.sign(s.diff())
+                se = np.sign(ema.diff())
+                mask = sc.ne(0) & se.ne(0) & sc.notna() & se.notna()
+                if mask.sum() == 0: out[sym]=float("nan"); continue
+                out[sym] = float((sc[mask] == se[mask]).mean())
+            except Exception:
+                out[sym]=float("nan")
+
+        res = pv[["symbol"]].copy(); res["value"] = res["symbol"].map(out); return res
+
+feature = EMA20TrendAlignShare()

--- a/cube2mat/features/iqr_logret.py
+++ b/cube2mat/features/iqr_logret.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+def _rth(df): return df.between_time("09:30","15:59")
+def _logret(s): return np.log(s.astype(float)).diff()
+
+class IQRLogRet(BaseFeature):
+    name = "iqr_logret"
+    description = "Interquartile range (Q3−Q1) of intraday log returns within RTH."
+    required_full_columns = ("symbol","time","close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx,date,columns=list(self.required_full_columns))
+        pv = self.load_pv(ctx,date,columns=["symbol"])
+        if df is None or pv is None: return None
+        df = self.ensure_et_index(df, time_col="time", tz=ctx.tz)
+
+        out={}
+        for sym,g in df.groupby("symbol", observed=True):
+            try:
+                r = _logret(_rth(g)["close"]).dropna().values
+                out[sym] = float(np.nanquantile(r, 0.75) - np.nanquantile(r, 0.25)) if r.size>0 else float("nan")
+            except Exception:
+                out[sym]=float("nan")
+        res = pv[["symbol"]].copy(); res["value"] = res["symbol"].map(out); return res
+
+feature = IQRLogRet()

--- a/cube2mat/features/katz_fd_close.py
+++ b/cube2mat/features/katz_fd_close.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+def _katz_fd(x: pd.Series) -> float:
+    s = pd.Series(x).astype(float).dropna()
+    n = s.size
+    if n < 3:
+        return float("nan")
+    L = float(np.abs(np.diff(s.values)).sum())
+    if not np.isfinite(L) or L <= 0:
+        return float("nan")
+    d = float(np.max(np.abs(s.values - s.values[0])))
+    if not np.isfinite(d) or d <= 0:
+        return float("nan")
+    a = L / (n - 1.0)
+    return float(np.log10(n) / (np.log10(n) + np.log10(d / a)))
+
+class KatzFDClose(BaseFeature):
+    name = "katz_fd_close"
+    description = "Katz fractal dimension of the close path during RTH (09:30–15:59); higher = more tortuous."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df_full = self.load_full(ctx, date, columns=list(self.required_full_columns))
+        sample  = self.load_pv(ctx, date, columns=["symbol"])
+        if df_full is None or sample is None:
+            return None
+        df_full = self.ensure_et_index(df_full, time_col="time", tz=ctx.tz)
+
+        out = {}
+        for sym, g in df_full.groupby("symbol", observed=True):
+            try:
+                val = _katz_fd(_rth(g)["close"])
+            except Exception:
+                val = float("nan")
+            out[sym] = val
+
+        res = sample[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+feature = KatzFDClose()

--- a/cube2mat/features/midday_smallmove_share_q25.py
+++ b/cube2mat/features/midday_smallmove_share_q25.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+def _rth(df): return df.between_time("09:30","15:59")
+def _logret(s): return np.log(s.astype(float)).diff()
+
+class MiddaySmallMoveShareQ25(BaseFeature):
+    name = "midday_smallmove_share_q25"
+    description = "Share of bars in 11:00–14:00 with |logret| ≤ overall RTH 25th percentile of |logret|."
+    required_full_columns = ("symbol","time","close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx,date,columns=list(self.required_full_columns))
+        pv = self.load_pv(ctx,date,columns=["symbol"])
+        if df is None or pv is None: return None
+        df = self.ensure_et_index(df, time_col="time", tz=ctx.tz)
+
+        out={}
+        for sym,g in df.groupby("symbol", observed=True):
+            try:
+                z = _rth(g)["close"].dropna()
+                r = _logret(z).dropna()
+                if r.empty: out[sym]=float("nan"); continue
+                q25 = float(np.nanquantile(np.abs(r.values), 0.25))
+                mid_idx = _rth(g).between_time("11:00","14:00").index
+                rm = r.loc[r.index.intersection(mid_idx)]
+                out[sym] = float((np.abs(rm.values) <= q25).mean()) if rm.size>0 else float("nan")
+            except Exception:
+                out[sym]=float("nan")
+        res = pv[["symbol"]].copy(); res["value"] = res["symbol"].map(out); return res
+
+feature = MiddaySmallMoveShareQ25()

--- a/cube2mat/features/premkt_gap_fill_ratio.py
+++ b/cube2mat/features/premkt_gap_fill_ratio.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+def _premkt(df): return df.between_time("00:00","09:29")
+def _rth(df): return df.between_time("09:30","15:59")
+
+class PreMktGapFillRatio(BaseFeature):
+    name = "premkt_gap_fill_ratio"
+    description = "Gap-fill ratio vs premarket: -(close_RTH_last - open_RTH_first) / (open_RTH_first - premarket_last_close). 1=完全回补，>1=过度回补。"
+    required_full_columns = ("symbol","time","open","close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx,date,columns=list(self.required_full_columns))
+        pv = self.load_pv(ctx,date,columns=["symbol"])
+        if df is None or pv is None: return None
+        df = self.ensure_et_index(df, time_col="time", tz=ctx.tz)
+
+        out={}
+        for sym,g in df.groupby("symbol", observed=True):
+            try:
+                pre = _premkt(g)[["close"]].dropna()
+                rth = _rth(g)[["open","close"]].dropna()
+                if pre.empty or rth.empty: out[sym]=float("nan"); continue
+                pre_last = float(pre["close"].iloc[-1])
+                op = float(rth["open"].iloc[0])
+                cl = float(rth["close"].iloc[-1])
+                gap = op - pre_last
+                if not np.isfinite(gap) or gap == 0:
+                    out[sym] = float("nan")
+                else:
+                    out[sym] = float(-(cl - op)/gap)
+            except Exception:
+                out[sym]=float("nan")
+        res = pv[["symbol"]].copy(); res["value"] = res["symbol"].map(out); return res
+
+feature = PreMktGapFillRatio()

--- a/cube2mat/features/range_to_rv_sqrt_ratio.py
+++ b/cube2mat/features/range_to_rv_sqrt_ratio.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+def _rth(df): return df.between_time("09:30", "15:59")
+def _logret(s): return np.log(s.astype(float)).diff()
+
+class RangeToRVSqrtRatio(BaseFeature):
+    name = "range_to_rv_sqrt_ratio"
+    description = "Log session range log(high_max/low_min) divided by sqrt(Σ r^2) using RTH log-returns."
+    required_full_columns = ("symbol", "time", "high", "low", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=list(self.required_full_columns))
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None: return None
+        df = self.ensure_et_index(df, time_col="time", tz=ctx.tz)
+
+        out={}
+        for sym,g in df.groupby("symbol", observed=True):
+            try:
+                d = _rth(g)[["high","low","close"]].dropna()
+                if d.empty: out[sym]=float("nan"); continue
+                rng = float(np.log(d["high"].max()/d["low"].min()))
+                r = _logret(d["close"]).dropna().values
+                denom = float(np.sqrt(np.sum(r**2)))
+                out[sym] = float(rng/denom) if np.isfinite(denom) and denom>0 else float("nan")
+            except Exception:
+                out[sym]=float("nan")
+        res = pv[["symbol"]].copy(); res["value"]=res["symbol"].map(out); return res
+
+feature = RangeToRVSqrtRatio()

--- a/cube2mat/features/ret_up_down_abs_magnitude_ratio.py
+++ b/cube2mat/features/ret_up_down_abs_magnitude_ratio.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+def _rth(df): return df.between_time("09:30","15:59")
+def _logret(s): return np.log(s.astype(float)).diff()
+
+class RetUpDownAbsMagnitudeRatio(BaseFeature):
+    name = "ret_up_down_abs_magnitude_ratio"
+    description = "Sum of positive |r| divided by sum of negative |r| for RTH log-returns."
+    required_full_columns = ("symbol","time","close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx,date,columns=list(self.required_full_columns))
+        pv = self.load_pv(ctx,date,columns=["symbol"])
+        if df is None or pv is None: return None
+        df = self.ensure_et_index(df, time_col="time", tz=ctx.tz)
+
+        out={}
+        for sym,g in df.groupby("symbol", observed=True):
+            try:
+                r = _logret(_rth(g)["close"]).dropna().values
+                if r.size == 0: out[sym]=float("nan"); continue
+                up = float(np.sum(np.maximum(r, 0.0)))
+                dn = float(np.sum(np.maximum(-r, 0.0)))
+                out[sym] = float(up/dn) if np.isfinite(dn) and dn>0 else float("nan")
+            except Exception:
+                out[sym]=float("nan")
+        res = pv[["symbol"]].copy(); res["value"] = res["symbol"].map(out); return res
+
+feature = RetUpDownAbsMagnitudeRatio()

--- a/cube2mat/features/return_vol_u_shape_ratio.py
+++ b/cube2mat/features/return_vol_u_shape_ratio.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+def _rth(df): return df.between_time("09:30", "15:59")
+def _logret(s: pd.Series) -> pd.Series: return np.log(s.astype(float)).diff()
+
+class ReturnVolUShapeRatio(BaseFeature):
+    name = "return_vol_u_shape_ratio"
+    description = "((std r in 09:30–10:29 + std r in 15:00–15:59)/2) / std r in 11:00–14:00 (log-returns)."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=list(self.required_full_columns))
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None: return None
+        df = self.ensure_et_index(df, time_col="time", tz=ctx.tz)
+
+        out={}
+        for sym,g in df.groupby("symbol", observed=True):
+            try:
+                z = _rth(g)[["close"]].dropna()
+                r = _logret(z["close"]).dropna()
+                if r.empty: out[sym]=float("nan"); continue
+                r_idx = r.index
+                early = r.loc[_rth(g).between_time("09:30","10:29").index.intersection(r_idx)]
+                mid   = r.loc[_rth(g).between_time("11:00","14:00").index.intersection(r_idx)]
+                late  = r.loc[_rth(g).between_time("15:00","15:59").index.intersection(r_idx)]
+                def _std(x): return float(np.std(x.values, ddof=1)) if x.size>=2 else np.nan
+                e, m, l = _std(early), _std(mid), _std(late)
+                out[sym] = float(((e+l)/2)/m) if np.isfinite(m) and m>0 and np.isfinite(e) and np.isfinite(l) else float("nan")
+            except Exception:
+                out[sym]=float("nan")
+
+        res = pv[["symbol"]].copy(); res["value"]=res["symbol"].map(out); return res
+
+feature = ReturnVolUShapeRatio()

--- a/cube2mat/features/tail_imbalance_q95_logret.py
+++ b/cube2mat/features/tail_imbalance_q95_logret.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+def _rth(df): return df.between_time("09:30","15:59")
+def _logret(s): return np.log(s.astype(float)).diff()
+
+class TailImbalanceQ95LogRet(BaseFeature):
+    name = "tail_imbalance_q95_logret"
+    description = "Tail imbalance at 95%% of |r|: (count[r≤−t] − count[r≥+t]) / (count[r≤−t] + count[r≥+t])."
+    required_full_columns = ("symbol","time","close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx,date,columns=list(self.required_full_columns))
+        pv = self.load_pv(ctx,date,columns=["symbol"])
+        if df is None or pv is None: return None
+        df = self.ensure_et_index(df, time_col="time", tz=ctx.tz)
+
+        out={}
+        for sym,g in df.groupby("symbol", observed=True):
+            try:
+                r = _logret(_rth(g)["close"]).dropna()
+                if r.empty: out[sym]=float("nan"); continue
+                t = float(np.nanquantile(np.abs(r.values), 0.95))
+                neg = int((r.values <= -t).sum()); pos = int((r.values >= +t).sum())
+                denom = neg + pos
+                out[sym] = float((neg - pos)/denom) if denom>0 else float("nan")
+            except Exception:
+                out[sym]=float("nan")
+        res = pv[["symbol"]].copy(); res["value"] = res["symbol"].map(out); return res
+
+feature = TailImbalanceQ95LogRet()

--- a/cube2mat/features/total_variation_close.py
+++ b/cube2mat/features/total_variation_close.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+def _rth(df): return df.between_time("09:30","15:59")
+
+class TotalVariationClose(BaseFeature):
+    name = "total_variation_close"
+    description = "Sum of absolute price changes Σ|Δclose| within RTH (path length in price units)."
+    required_full_columns = ("symbol","time","close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx,date,columns=list(self.required_full_columns))
+        pv = self.load_pv(ctx,date,columns=["symbol"])
+        if df is None or pv is None: return None
+        df = self.ensure_et_index(df, time_col="time", tz=ctx.tz)
+
+        out={}
+        for sym,g in df.groupby("symbol", observed=True):
+            try:
+                s = _rth(g)["close"].astype(float).dropna()
+                out[sym] = float(np.abs(np.diff(s.values)).sum()) if s.size>=2 else float("nan")
+            except Exception:
+                out[sym]=float("nan")
+
+        res = pv[["symbol"]].copy(); res["value"] = res["symbol"].map(out); return res
+
+feature = TotalVariationClose()

--- a/cube2mat/features/turning_point_rate_close.py
+++ b/cube2mat/features/turning_point_rate_close.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+def _rth(df): return df.between_time("09:30", "15:59")
+
+class TurningPointRateClose(BaseFeature):
+    name = "turning_point_rate_close"
+    description = "Fraction of interior RTH bars that are local turning points of close (sign of Δclose flips; endpoints excluded)."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=list(self.required_full_columns))
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, time_col="time", tz=ctx.tz)
+
+        out = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            try:
+                s = _rth(g)["close"].astype(float).dropna()
+                if s.size < 3:
+                    out[sym] = float("nan"); continue
+                d = s.diff().to_numpy()
+                sign = np.sign(d)
+                mid = sign[1:-1]; nxt = sign[2:]
+                valid = (mid != 0) & (nxt != 0)
+                if mid.size == 0:
+                    out[sym] = float("nan"); continue
+                tp = ((mid * nxt) < 0) & valid
+                out[sym] = float(tp.sum() / (s.size - 2))
+            except Exception:
+                out[sym] = float("nan")
+
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+feature = TurningPointRateClose()

--- a/cube2mat/features/volume_median_to_mean_ratio.py
+++ b/cube2mat/features/volume_median_to_mean_ratio.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+def _rth(df): return df.between_time("09:30", "15:59")
+
+class VolumeMedianToMeanRatio(BaseFeature):
+    name = "volume_median_to_mean_ratio"
+    description = "Median(volume)/Mean(volume) within RTH; concentration/robustness proxy for volume distribution."
+    required_full_columns = ("symbol", "time", "volume")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=list(self.required_full_columns))
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, time_col="time", tz=ctx.tz)
+
+        out={}
+        for sym, g in df.groupby("symbol", observed=True):
+            try:
+                v = _rth(g)["volume"].astype(float).dropna()
+                m = float(v.mean())
+                out[sym] = float(np.median(v.values)/m) if np.isfinite(m) and m>0 else float("nan")
+            except Exception:
+                out[sym] = float("nan")
+
+        res = pv[["symbol"]].copy(); res["value"] = res["symbol"].map(out); return res
+
+feature = VolumeMedianToMeanRatio()

--- a/cube2mat/features/vwap_dev_rel_median_abs.py
+++ b/cube2mat/features/vwap_dev_rel_median_abs.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+def _rth(df): return df.between_time("09:30","15:59")
+
+class VWAPDevRelMedianAbs(BaseFeature):
+    name = "vwap_dev_rel_median_abs"
+    description = "Median of |(close - vwap)/vwap| across RTH bars (robust VWAP deviation scale)."
+    required_full_columns = ("symbol","time","close","vwap")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx,date,columns=list(self.required_full_columns))
+        pv = self.load_pv(ctx,date,columns=["symbol"])
+        if df is None or pv is None: return None
+        df = self.ensure_et_index(df, time_col="time", tz=ctx.tz)
+
+        out={}
+        for sym,g in df.groupby("symbol", observed=True):
+            try:
+                d = _rth(g)[["close","vwap"]].dropna()
+                if d.empty: out[sym]=float("nan"); continue
+                dev = (d["close"].astype(float) - d["vwap"].astype(float)) / d["vwap"].astype(float)
+                dev = dev.replace([np.inf, -np.inf], np.nan).dropna()
+                out[sym] = float(np.median(np.abs(dev.values))) if dev.size>0 else float("nan")
+            except Exception:
+                out[sym]=float("nan")
+        res = pv[["symbol"]].copy(); res["value"] = res["symbol"].map(out); return res
+
+feature = VWAPDevRelMedianAbs()


### PR DESCRIPTION
## Summary
- add Katz fractal dimension of close path
- add turning-point rate and other intraday volatility/volume metrics
- include VWAP deviation, premarket gap-fill, EMA trend alignment, and more

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68a33706e530832a89b3654fa2008226