### PR TITLE
Add compaction, shock, and run statistics features

### DIFF
--- a/cube2mat/features/absret_compaction_80pct_bars_frac.py
+++ b/cube2mat/features/absret_compaction_80pct_bars_frac.py
@@ -1,0 +1,51 @@
+# features/absret_compaction_80pct_bars_frac.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+
+def _logret(s: pd.Series) -> pd.Series:
+    return np.log(s.astype(float)).diff()
+
+
+class AbsRetCompaction80PctBarsFracFeature(BaseFeature):
+    name = "absret_compaction_80pct_bars_frac"
+    description = (
+        "Fraction of RTH bars needed to accumulate 80% of Σ|r| (log-returns), sorting |r| descending."
+    )
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=["symbol", "time", "close"])
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            ar = _logret(_rth(g)["close"]).dropna().abs().values
+            n = ar.size
+            if n == 0:
+                out[sym] = float("nan")
+                continue
+            tot = float(ar.sum())
+            if tot <= 0 or not np.isfinite(tot):
+                out[sym] = float("nan")
+                continue
+            srt = np.sort(ar)[::-1]
+            cs = np.cumsum(srt)
+            k = int(np.searchsorted(cs, 0.8 * tot, side="left")) + 1
+            out[sym] = float(k / n)
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = AbsRetCompaction80PctBarsFracFeature()

--- a/cube2mat/features/bars_to_50pct_volume_time_frac.py
+++ b/cube2mat/features/bars_to_50pct_volume_time_frac.py
@@ -1,0 +1,46 @@
+# features/bars_to_50pct_volume_time_frac.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+
+class BarsTo50PctVolumeTimeFracFeature(BaseFeature):
+    name = "bars_to_50pct_volume_time_frac"
+    description = (
+        "In time order, fraction of RTH bars elapsed when cumulative volume first reaches 50% of the day's total."
+    )
+    required_full_columns = ("symbol", "time", "volume")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=["symbol", "time", "volume"])
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            v = _rth(g)["volume"].astype(float).dropna()
+            n = v.size
+            if n == 0:
+                out[sym] = float("nan")
+                continue
+            tot = float(v.sum())
+            if tot <= 0 or not np.isfinite(tot):
+                out[sym] = float("nan")
+                continue
+            cs = v.cumsum().values
+            k = int(np.searchsorted(cs, 0.5 * tot, side="left")) + 1
+            out[sym] = float(k / n)
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = BarsTo50PctVolumeTimeFracFeature()

--- a/cube2mat/features/early_vs_late_run_count_ratio.py
+++ b/cube2mat/features/early_vs_late_run_count_ratio.py
@@ -1,0 +1,48 @@
+# features/early_vs_late_run_count_ratio.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _logret(s: pd.Series) -> pd.Series:
+    return np.log(s.astype(float)).diff()
+
+
+class EarlyVsLateRunCountRatioFeature(BaseFeature):
+    name = "early_vs_late_run_count_ratio"
+    description = (
+        "Run count in 09:30–10:29 divided by run count in 15:00–15:59 (sign runs of log-returns; zeros break runs)."
+    )
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def _run_count_in_window(self, g: pd.DataFrame, start: str, end: str) -> float:
+        z = g.between_time(start, end)["close"].astype(float).dropna()
+        r = _logret(z).dropna()
+        if r.empty:
+            return np.nan
+        s = np.sign(r.values)
+        s = pd.Series(s).replace(0, np.nan).dropna()
+        if s.empty:
+            return np.nan
+        return float((s != s.shift()).sum())
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=["symbol", "time", "close"])
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            early = self._run_count_in_window(g, "09:30", "10:29")
+            late = self._run_count_in_window(g, "15:00", "15:59")
+            out[sym] = float(early / late) if np.isfinite(late) and late > 0 else float("nan")
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = EarlyVsLateRunCountRatioFeature()

--- a/cube2mat/features/max_drawdown_depth_per_bar.py
+++ b/cube2mat/features/max_drawdown_depth_per_bar.py
@@ -1,0 +1,49 @@
+# features/max_drawdown_depth_per_bar.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+
+class MaxDrawdownDepthPerBarFeature(BaseFeature):
+    name = "max_drawdown_depth_per_bar"
+    description = (
+        "Maximum drawdown depth divided by its duration in bars (uses close; depth as positive number)."
+    )
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=["symbol", "time", "close"])
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            s = _rth(g)["close"].astype(float).dropna().values
+            n = s.size
+            if n < 2:
+                out[sym] = float("nan")
+                continue
+            run_max = np.maximum.accumulate(s)
+            dd = s / run_max - 1.0
+            trough = int(np.argmin(dd))
+            if trough == 0:
+                out[sym] = float("nan")
+                continue
+            peak = int(np.argmax(s[: trough + 1]))
+            depth = -float(dd[trough])
+            dur = trough - peak
+            out[sym] = float(depth / dur) if dur > 0 else float("nan")
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = MaxDrawdownDepthPerBarFeature()

--- a/cube2mat/features/return_contribution_top_quintile_by_volume.py
+++ b/cube2mat/features/return_contribution_top_quintile_by_volume.py
@@ -1,0 +1,52 @@
+# features/return_contribution_top_quintile_by_volume.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+
+def _logret(s: pd.Series) -> pd.Series:
+    return np.log(s.astype(float)).diff()
+
+
+class ReturnContributionTopQuintileByVolumeFeature(BaseFeature):
+    name = "return_contribution_top_quintile_by_volume"
+    description = (
+        "Share of Σ|r| contributed by bars in the top 20% of volume (threshold by volume 80th percentile)."
+    )
+    required_full_columns = ("symbol", "time", "close", "volume")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=["symbol", "time", "close", "volume"])
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            gg = _rth(g)[["close", "volume"]].dropna()
+            if gg.empty:
+                out[sym] = float("nan")
+                continue
+            r = _logret(gg["close"]).dropna()
+            if r.empty:
+                out[sym] = float("nan")
+                continue
+            v = gg["volume"].astype(float).reindex(r.index)
+            thr = float(np.nanquantile(v.values, 0.80))
+            mask = v.values >= thr
+            num = float(np.abs(r.values[mask]).sum())
+            den = float(np.abs(r.values).sum())
+            out[sym] = (num / den) if den > 0 and np.isfinite(den) else float("nan")
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = ReturnContributionTopQuintileByVolumeFeature()

--- a/cube2mat/features/run_balance_index.py
+++ b/cube2mat/features/run_balance_index.py
@@ -1,0 +1,68 @@
+# features/run_balance_index.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+
+def _logret(s: pd.Series) -> pd.Series:
+    return np.log(s.astype(float)).diff()
+
+
+def _run_lengths(sgn: pd.Series, positive: bool = True):
+    s = pd.Series(sgn).astype(int)
+    s[s == 0] = 0
+    s = s.replace({1: 1, -1: -1})
+    if positive:
+        mask = (s == 1).astype(int)
+    else:
+        mask = (s == -1).astype(int)
+    if mask.sum() == 0:
+        return []
+    diff = mask.diff().fillna(0).values
+    starts = np.where(diff == 1)[0]
+    if mask.iloc[0] == 1:
+        starts = np.r_[0, starts]
+    ends = np.where(diff == -1)[0] - 1
+    if mask.iloc[-1] == 1:
+        ends = np.r_[ends, len(mask) - 1]
+    return (ends - starts + 1).tolist()
+
+
+class RunBalanceIndexFeature(BaseFeature):
+    name = "run_balance_index"
+    description = (
+        "Run-balance index: (mean length of up runs − mean length of down runs) / (sum of the two means)."
+    )
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=["symbol", "time", "close"])
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            sgn = np.sign(_logret(_rth(g)["close"]).dropna().values)
+            ups = _run_lengths(pd.Series(sgn), positive=True)
+            dns = _run_lengths(pd.Series(sgn), positive=False)
+            if len(ups) == 0 or len(dns) == 0:
+                out[sym] = float("nan")
+                continue
+            mu_u = float(np.mean(ups))
+            mu_d = float(np.mean(dns))
+            denom = mu_u + mu_d
+            out[sym] = float((mu_u - mu_d) / denom) if denom > 0 else float("nan")
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = RunBalanceIndexFeature()

--- a/cube2mat/features/run_count_total.py
+++ b/cube2mat/features/run_count_total.py
@@ -1,0 +1,47 @@
+# features/run_count_total.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+
+def _logret(s: pd.Series) -> pd.Series:
+    return np.log(s.astype(float)).diff()
+
+
+def _run_count(signs: pd.Series) -> float:
+    s = pd.Series(signs).astype(int)
+    s = s.replace(0, np.nan).dropna()
+    if s.empty:
+        return float("nan")
+    return float((s != s.shift()).sum())
+
+
+class RunCountTotalFeature(BaseFeature):
+    name = "run_count_total"
+    description = "Total number of sign runs in intraday log-returns (zeros break runs)."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=["symbol", "time", "close"])
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            r = _logret(_rth(g)["close"]).dropna()
+            s = np.sign(r.values)
+            out[sym] = _run_count(pd.Series(s))
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = RunCountTotalFeature()

--- a/cube2mat/features/run_len_var_ratio_up_to_down.py
+++ b/cube2mat/features/run_len_var_ratio_up_to_down.py
@@ -1,0 +1,62 @@
+# features/run_len_var_ratio_up_to_down.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+
+def _logret(s: pd.Series) -> pd.Series:
+    return np.log(s.astype(float)).diff()
+
+
+def _run_lengths(sgn: pd.Series, positive: bool = True):
+    s = pd.Series(sgn).astype(int)
+    s[s == 0] = 0
+    s = s.replace({1: 1, -1: -1})
+    mask = (s == 1).astype(int) if positive else (s == -1).astype(int)
+    if mask.sum() == 0:
+        return []
+    diff = mask.diff().fillna(0).values
+    starts = np.where(diff == 1)[0]
+    if mask.iloc[0] == 1:
+        starts = np.r_[0, starts]
+    ends = np.where(diff == -1)[0] - 1
+    if mask.iloc[-1] == 1:
+        ends = np.r_[ends, len(mask) - 1]
+    return (ends - starts + 1).tolist()
+
+
+class RunLenVarRatioUpToDownFeature(BaseFeature):
+    name = "run_len_var_ratio_up_to_down"
+    description = "Variance of up-run lengths divided by variance of down-run lengths (zeros break runs)."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=["symbol", "time", "close"])
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            sgn = np.sign(_logret(_rth(g)["close"]).dropna().values)
+            ups = _run_lengths(pd.Series(sgn), True)
+            dns = _run_lengths(pd.Series(sgn), False)
+            if len(ups) < 2 or len(dns) < 2:
+                out[sym] = float("nan")
+                continue
+            vu = float(np.var(ups, ddof=1))
+            vd = float(np.var(dns, ddof=1))
+            out[sym] = float(vu / vd) if vd > 0 and np.isfinite(vd) else float("nan")
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = RunLenVarRatioUpToDownFeature()

--- a/cube2mat/features/rv_after_shock_share_k10.py
+++ b/cube2mat/features/rv_after_shock_share_k10.py
@@ -1,0 +1,58 @@
+# features/rv_after_shock_share_k10.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+
+def _logret(s: pd.Series) -> pd.Series:
+    return np.log(s.astype(float)).diff()
+
+
+class RVAfterShockShareK10Feature(BaseFeature):
+    name = "rv_after_shock_share_k10"
+    description = (
+        "Share of daily RV (Σr^2) occurring in the union of 10-bar windows that follow |r|≥Q90 shock bars."
+    )
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=["symbol", "time", "close"])
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            r = _logret(_rth(g)["close"]).dropna()
+            rv = np.square(r.values)
+            n = rv.size
+            if n == 0:
+                out[sym] = float("nan")
+                continue
+            thr = float(np.nanquantile(np.abs(r.values), 0.90))
+            shocks = np.where(np.abs(r.values) >= thr)[0]
+            if shocks.size == 0:
+                out[sym] = float("nan")
+                continue
+            mask = np.zeros(n, dtype=bool)
+            for i in shocks:
+                a = i + 1
+                b = min(i + 10, n - 1)
+                if a <= b:
+                    mask[a : b + 1] = True
+            num = float(rv[mask].sum())
+            den = float(rv.sum())
+            out[sym] = (num / den) if den > 0 and np.isfinite(den) else float("nan")
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = RVAfterShockShareK10Feature()

--- a/cube2mat/features/rv_compaction_50pct_bars_frac.py
+++ b/cube2mat/features/rv_compaction_50pct_bars_frac.py
@@ -1,0 +1,51 @@
+# features/rv_compaction_50pct_bars_frac.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+
+def _logret(s: pd.Series) -> pd.Series:
+    return np.log(s.astype(float)).diff()
+
+
+class RVCompaction50PctBarsFracFeature(BaseFeature):
+    name = "rv_compaction_50pct_bars_frac"
+    description = (
+        "Fraction of RTH bars needed to reach 50% of Σ r^2 (compaction at the half-mass of realized variance)."
+    )
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=["symbol", "time", "close"])
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            r = _logret(_rth(g)["close"]).dropna()
+            if r.size < 2:
+                out[sym] = float("nan")
+                continue
+            r2 = np.square(r.values)
+            tot = float(r2.sum())
+            if tot <= 0 or not np.isfinite(tot):
+                out[sym] = float("nan")
+                continue
+            srt = np.sort(r2)[::-1]
+            cs = np.cumsum(srt)
+            k = int(np.searchsorted(cs, 0.5 * tot, side="left")) + 1
+            out[sym] = float(k / r2.size)
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = RVCompaction50PctBarsFracFeature()

--- a/cube2mat/features/rv_compaction_80pct_bars_frac.py
+++ b/cube2mat/features/rv_compaction_80pct_bars_frac.py
@@ -1,0 +1,52 @@
+# features/rv_compaction_80pct_bars_frac.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+
+def _logret(s: pd.Series) -> pd.Series:
+    return np.log(s.astype(float)).diff()
+
+
+class RVCompaction80PctBarsFracFeature(BaseFeature):
+    name = "rv_compaction_80pct_bars_frac"
+    description = (
+        "Fraction of RTH bars (by count) needed to accumulate 80% of Σ r^2 (log-returns),"
+        " sorting r^2 descending."
+    )
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=["symbol", "time", "close"])
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, time_col="time", tz=ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            r = _logret(_rth(g)["close"]).dropna()
+            if r.size < 2:
+                out[sym] = float("nan")
+                continue
+            r2 = np.square(r.values)
+            tot = float(r2.sum())
+            if not np.isfinite(tot) or tot <= 0:
+                out[sym] = float("nan")
+                continue
+            srt = np.sort(r2)[::-1]
+            cs = np.cumsum(srt)
+            k = int(np.searchsorted(cs, 0.8 * tot, side="left")) + 1
+            out[sym] = float(k / r2.size)
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = RVCompaction80PctBarsFracFeature()

--- a/cube2mat/features/share_in_runs_len_ge3.py
+++ b/cube2mat/features/share_in_runs_len_ge3.py
@@ -1,0 +1,53 @@
+# features/share_in_runs_len_ge3.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+
+def _logret(s: pd.Series) -> pd.Series:
+    return np.log(s.astype(float)).diff()
+
+
+def _run_segments(sgn: np.ndarray):
+    s = pd.Series(sgn).astype(int).replace(0, np.nan).dropna().astype(int)
+    if s.empty:
+        return []
+    starts = (s != s.shift()).cumsum()
+    groups = s.groupby(starts)
+    return [(int(k), len(v)) for k, v in groups]
+
+
+class ShareInRunsLenGE3Feature(BaseFeature):
+    name = "share_in_runs_len_ge3"
+    description = "Share of return observations that belong to sign runs with length ≥ 3."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=["symbol", "time", "close"])
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            sgn = np.sign(_logret(_rth(g)["close"]).dropna().values)
+            segs = _run_segments(sgn)
+            total = len(sgn)
+            if total == 0:
+                out[sym] = float("nan")
+                continue
+            big = sum(L for _, L in segs if L >= 3)
+            out[sym] = float(big / total)
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = ShareInRunsLenGE3Feature()

--- a/cube2mat/features/shock_calm_time_median_q50.py
+++ b/cube2mat/features/shock_calm_time_median_q50.py
@@ -1,0 +1,56 @@
+# features/shock_calm_time_median_q50.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+
+def _logret(s: pd.Series) -> pd.Series:
+    return np.log(s.astype(float)).diff()
+
+
+class ShockCalmTimeMedianQ50Feature(BaseFeature):
+    name = "shock_calm_time_median_q50"
+    description = (
+        "Median bars needed after a |r|≥Q90 event for |r| to drop to ≤ median(|r|) again (log-returns, RTH)."
+    )
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=["symbol", "time", "close"])
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            r = _logret(_rth(g)["close"]).dropna().values
+            n = r.size
+            if n == 0:
+                out[sym] = float("nan")
+                continue
+            med = float(np.nanmedian(np.abs(r)))
+            thr = float(np.nanquantile(np.abs(r), 0.90))
+            shocks = np.where(np.abs(r) >= thr)[0]
+            times: list[int] = []
+            for i in shocks:
+                if i + 1 >= n:
+                    continue
+                h = 1
+                while i + h < n and np.abs(r[i + h]) > med:
+                    h += 1
+                if i + h < n:
+                    times.append(h)
+            out[sym] = float(np.median(times)) if len(times) > 0 else float("nan")
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = ShockCalmTimeMedianQ50Feature()

--- a/cube2mat/features/shock_cluster_density_q90_win5.py
+++ b/cube2mat/features/shock_cluster_density_q90_win5.py
@@ -1,0 +1,53 @@
+# features/shock_cluster_density_q90_win5.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+
+def _logret(s: pd.Series) -> pd.Series:
+    return np.log(s.astype(float)).diff()
+
+
+class ShockClusterDensityQ90Win5Feature(BaseFeature):
+    name = "shock_cluster_density_q90_win5"
+    description = (
+        "Fraction of |r|≥Q90 shock events that have another shock within ±5 bars (clustering density)."
+    )
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=["symbol", "time", "close"])
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            r = _logret(_rth(g)["close"]).dropna().values
+            n = r.size
+            if n == 0:
+                out[sym] = float("nan")
+                continue
+            thr = float(np.nanquantile(np.abs(r), 0.90))
+            idx = np.where(np.abs(r) >= thr)[0]
+            if idx.size == 0:
+                out[sym] = float("nan")
+                continue
+            flags: list[bool] = []
+            for i in idx:
+                near = idx[np.abs(idx - i) <= 5]
+                flags.append(True if (near.size > 1) else False)
+            out[sym] = float(np.mean(flags)) if len(flags) > 0 else float("nan")
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = ShockClusterDensityQ90Win5Feature()

--- a/cube2mat/features/shock_followthrough_score_k5.py
+++ b/cube2mat/features/shock_followthrough_score_k5.py
@@ -1,0 +1,53 @@
+# features/shock_followthrough_score_k5.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+
+def _logret(s: pd.Series) -> pd.Series:
+    return np.log(s.astype(float)).diff()
+
+
+class ShockFollowThroughScoreK5Feature(BaseFeature):
+    name = "shock_followthrough_score_k5"
+    description = (
+        "Mean of sign(r_shock) * sign(sum of next up-to-5 returns) for |r|≥Q90 events; +1 follow-through, -1 reversal."
+    )
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=["symbol", "time", "close"])
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            r = _logret(_rth(g)["close"]).dropna().values
+            n = r.size
+            if n == 0:
+                out[sym] = float("nan")
+                continue
+            thr = float(np.nanquantile(np.abs(r), 0.90))
+            idx = np.where(np.abs(r) >= thr)[0]
+            scores: list[float] = []
+            for i in idx:
+                if i + 1 >= n:
+                    continue
+                k = min(5, n - (i + 1))
+                sgn_next = np.sign(np.sum(r[i + 1 : i + 1 + k]))
+                scores.append(np.sign(r[i]) * sgn_next)
+            out[sym] = float(np.mean(scores)) if len(scores) > 0 else float("nan")
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = ShockFollowThroughScoreK5Feature()

--- a/cube2mat/features/shock_nextbar_reversion_ratio.py
+++ b/cube2mat/features/shock_nextbar_reversion_ratio.py
@@ -1,0 +1,54 @@
+# features/shock_nextbar_reversion_ratio.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+
+def _logret(s: pd.Series) -> pd.Series:
+    return np.log(s.astype(float)).diff()
+
+
+class ShockNextBarReversionRatioFeature(BaseFeature):
+    name = "shock_nextbar_reversion_ratio"
+    description = (
+        "Mean of [-sign(r_t)*r_{t+1}/|r_t|] over |r_t|≥Q90 events (log-returns). +值代表平均次棒反转。"
+    )
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=["symbol", "time", "close"])
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            r = _logret(_rth(g)["close"]).dropna().values
+            n = r.size
+            if n < 2:
+                out[sym] = float("nan")
+                continue
+            thr = float(np.nanquantile(np.abs(r), 0.90))
+            idx = np.where(np.abs(r) >= thr)[0]
+            vals: list[float] = []
+            for i in idx:
+                if i + 1 >= n:
+                    continue
+                denom = np.abs(r[i])
+                if denom <= 0 or not np.isfinite(denom):
+                    continue
+                vals.append(-np.sign(r[i]) * r[i + 1] / denom)
+            out[sym] = float(np.mean(vals)) if len(vals) > 0 else float("nan")
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = ShockNextBarReversionRatioFeature()

--- a/cube2mat/features/signret_majority_agreement_share_m5.py
+++ b/cube2mat/features/signret_majority_agreement_share_m5.py
@@ -1,0 +1,57 @@
+# features/signret_majority_agreement_share_m5.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+
+def _logret(s: pd.Series) -> pd.Series:
+    return np.log(s.astype(float)).diff()
+
+
+class SignRetMajorityAgreementShareM5Feature(BaseFeature):
+    name = "signret_majority_agreement_share_m5"
+    description = (
+        "Share of bars where sign(r_t) equals the majority sign of the previous 5 nonzero returns (ties/insufficient skipped)."
+    )
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=["symbol", "time", "close"])
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            r = _logret(_rth(g)["close"]).dropna()
+            if r.size < 6:
+                out[sym] = float("nan")
+                continue
+            s = np.sign(r.values)
+            ok = 0
+            hit = 0
+            for t in range(5, len(s)):
+                prev = s[t - 5 : t]
+                prev = prev[prev != 0]
+                if prev.size == 0:
+                    continue
+                maj = np.sign(prev.sum())
+                if maj == 0:
+                    continue
+                ok += 1
+                if s[t] == maj:
+                    hit += 1
+            out[sym] = float(hit / ok) if ok > 0 else float("nan")
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = SignRetMajorityAgreementShareM5Feature()

--- a/cube2mat/features/swing_amplitude_median.py
+++ b/cube2mat/features/swing_amplitude_median.py
@@ -1,0 +1,58 @@
+# features/swing_amplitude_median.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+
+def _logret(s: pd.Series) -> pd.Series:
+    return np.log(s.astype(float)).diff()
+
+
+def _run_amplitudes(sgn: np.ndarray, r: np.ndarray):
+    s = pd.Series(sgn).astype(int).replace(0, np.nan).dropna().astype(int)
+    if s.empty:
+        return []
+    idx = s.index.to_numpy()
+    starts = (s != s.shift()).cumsum()
+    amps: list[float] = []
+    for _, loc in s.groupby(starts).groups.items():
+        loc = list(loc)
+        amps.append(np.abs(r[idx[loc]].sum()))
+    return amps
+
+
+class SwingAmplitudeMedianFeature(BaseFeature):
+    name = "swing_amplitude_median"
+    description = (
+        "Median absolute swing amplitude per sign run (sum of returns over the run, absolute value)."
+    )
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=["symbol", "time", "close"])
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            r = _logret(_rth(g)["close"]).dropna().values
+            if r.size == 0:
+                out[sym] = float("nan")
+                continue
+            s = np.sign(r)
+            amps = _run_amplitudes(s, r)
+            out[sym] = float(np.median(amps)) if len(amps) > 0 else float("nan")
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = SwingAmplitudeMedianFeature()

--- a/cube2mat/features/time_to_first_extreme_q90_absret_frac.py
+++ b/cube2mat/features/time_to_first_extreme_q90_absret_frac.py
@@ -1,0 +1,46 @@
+# features/time_to_first_extreme_q90_absret_frac.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+
+def _logret(s: pd.Series) -> pd.Series:
+    return np.log(s.astype(float)).diff()
+
+
+class TimeToFirstExtremeQ90AbsRetFracFeature(BaseFeature):
+    name = "time_to_first_extreme_q90_absret_frac"
+    description = (
+        "Fraction of RTH returns elapsed when |r| first crosses the 90th percentile of |r| (intraday log-returns)."
+    )
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=["symbol", "time", "close"])
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            r = _logret(_rth(g)["close"]).dropna().values
+            n = r.size
+            if n == 0:
+                out[sym] = float("nan")
+                continue
+            thr = float(np.nanquantile(np.abs(r), 0.90))
+            idx = np.where(np.abs(r) >= thr)[0]
+            out[sym] = float((idx[0] + 1) / n) if idx.size > 0 else float("nan")
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = TimeToFirstExtremeQ90AbsRetFracFeature()

--- a/cube2mat/features/volume_compaction_80pct_bars_frac.py
+++ b/cube2mat/features/volume_compaction_80pct_bars_frac.py
@@ -1,0 +1,46 @@
+# features/volume_compaction_80pct_bars_frac.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+
+class VolumeCompaction80PctBarsFracFeature(BaseFeature):
+    name = "volume_compaction_80pct_bars_frac"
+    description = (
+        "Fraction of RTH bars needed to accumulate 80% of total volume (bars sorted by volume descending)."
+    )
+    required_full_columns = ("symbol", "time", "volume")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=["symbol", "time", "volume"])
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            v = _rth(g)["volume"].astype(float).dropna().values
+            if v.size == 0:
+                out[sym] = float("nan")
+                continue
+            tot = float(v.sum())
+            if tot <= 0 or not np.isfinite(tot):
+                out[sym] = float("nan")
+                continue
+            srt = np.sort(v)[::-1]
+            cs = np.cumsum(srt)
+            k = int(np.searchsorted(cs, 0.8 * tot, side="left")) + 1
+            out[sym] = float(k / v.size)
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = VolumeCompaction80PctBarsFracFeature()

--- a/cube2mat/features/volume_top3_share.py
+++ b/cube2mat/features/volume_top3_share.py
@@ -1,0 +1,42 @@
+# features/volume_top3_share.py
+from __future__ import annotations
+import datetime as dt
+import numpy as np
+import pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+
+class VolumeTop3ShareFeature(BaseFeature):
+    name = "volume_top3_share"
+    description = "Share of total RTH volume contributed by the top-3 volume bars."
+    required_full_columns = ("symbol", "time", "volume")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=["symbol", "time", "volume"])
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            v = _rth(g)["volume"].astype(float).dropna().values
+            if v.size == 0:
+                out[sym] = float("nan")
+                continue
+            tot = float(v.sum())
+            if tot <= 0 or not np.isfinite(tot):
+                out[sym] = float("nan")
+                continue
+            top3 = float(np.sort(v)[-3:].sum()) if v.size >= 3 else float(np.sort(v).sum())
+            out[sym] = top3 / tot
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = VolumeTop3ShareFeature()


### PR DESCRIPTION
## Summary
- add realized variance and volume compaction indicators
- add shock analysis metrics including follow-through score and RV share after shocks
- add run-based statistics and drawdown depth-per-bar feature

## Testing
- `pytest -q` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68a34504b814832ab5706c73f097af93