### PR TITLE
feat: add intraday shape, motif, and flow features

### DIFF
--- a/cube2mat/features/absret_per_volume.py
+++ b/cube2mat/features/absret_per_volume.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+import datetime as dt, numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+
+def _logret(s: pd.Series) -> pd.Series:
+    return np.log(s.astype(float)).diff()
+
+
+class AbsRetPerVolume(BaseFeature):
+    name = "absret_per_volume"
+    description = "Σ|r| (log-returns) divided by total volume in RTH."
+    required_full_columns = ("symbol", "time", "close", "volume")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=["symbol", "time", "close", "volume"])
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            gg = _rth(g)[["close", "volume"]].dropna()
+            r = _logret(gg["close"]).dropna().values
+            totv = float(gg["volume"].sum())
+            out[sym] = float(np.sum(np.abs(r)) / totv) if r.size > 0 and totv > 0 and np.isfinite(totv) else float("nan")
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = AbsRetPerVolume()

--- a/cube2mat/features/approx_entropy_absret_m2_r02.py
+++ b/cube2mat/features/approx_entropy_absret_m2_r02.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+import datetime as dt, numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+
+def _logret(s: pd.Series) -> pd.Series:
+    return np.log(s.astype(float)).diff()
+
+
+def _apen(x: np.ndarray, m: int = 2, r: float | None = None) -> float:
+    x = np.asarray(x, dtype=float)
+    n = x.size
+    if n <= m + 1:
+        return float("nan")
+    if r is None:
+        r = 0.2 * np.nanstd(x)
+        if not np.isfinite(r) or r <= 0:
+            return float("nan")
+    def _phi(mm: int) -> float:
+        C = []
+        for i in range(n - mm + 1):
+            xi = x[i : i + mm]
+            d = np.max(np.abs(x[i : i + mm][None, :] - x[np.arange(n - mm + 1)][:, None, :mm]), axis=2)
+            C.append(np.mean((d <= r).astype(float)))
+        C = np.array(C)
+        C = C[C > 0]
+        return float(np.mean(np.log(C))) if C.size > 0 else float("nan")
+    p1 = _phi(m)
+    p2 = _phi(m + 1)
+    return float(p1 - p2) if np.isfinite(p1) and np.isfinite(p2) else float("nan")
+
+
+class ApproxEntropyAbsRetM2R02(BaseFeature):
+    name = "approx_entropy_absret_m2_r02"
+    description = "Approximate Entropy of |log returns| with m=2, r=0.2·std(|r|) within RTH."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=["symbol", "time", "close"])
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            r = np.abs(_logret(_rth(g)["close"]).dropna().values)
+            out[sym] = _apen(r, m=2, r=0.2 * np.nanstd(r)) if r.size > 5 else float("nan")
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"] .map(out)
+        return res
+
+
+feature = ApproxEntropyAbsRetM2R02()

--- a/cube2mat/features/close_to_edge_distance_frac.py
+++ b/cube2mat/features/close_to_edge_distance_frac.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+import datetime as dt, numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+
+class CloseToEdgeDistanceFrac(BaseFeature):
+    name = "close_to_edge_distance_frac"
+    description = "Normalized edge proximity: min(C-L, H-C)/(H-L) using RTH H/L and last close."
+    required_full_columns = ("symbol", "time", "high", "low", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=list(self.required_full_columns))
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            d = _rth(g)[["high", "low", "close"]].dropna()
+            if d.empty:
+                out[sym] = float("nan")
+                continue
+            H, L, C = float(d["high"].max()), float(d["low"].min()), float(d["close"].iloc[-1])
+            rng = H - L
+            out[sym] = float(min(C - L, H - C) / rng) if np.isfinite(rng) and rng > 0 else float("nan")
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = CloseToEdgeDistanceFrac()

--- a/cube2mat/features/end_position_in_range.py
+++ b/cube2mat/features/end_position_in_range.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+import datetime as dt, numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+
+class EndPositionInRange(BaseFeature):
+    name = "end_position_in_range"
+    description = "Position of close in the session range: (C - L) / (H - L) ∈ [0,1]."
+    required_full_columns = ("symbol", "time", "high", "low", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=list(self.required_full_columns))
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            d = _rth(g)[["high", "low", "close"]].dropna()
+            if d.empty:
+                out[sym] = float("nan")
+                continue
+            H, L, C = float(d["high"].max()), float(d["low"].min()), float(d["close"].iloc[-1])
+            rng = H - L
+            out[sym] = float((C - L) / rng) if np.isfinite(rng) and rng > 0 else float("nan")
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = EndPositionInRange()

--- a/cube2mat/features/endgame_drift_share_last60.py
+++ b/cube2mat/features/endgame_drift_share_last60.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+import datetime as dt, numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _logret(s: pd.Series) -> pd.Series:
+    return np.log(s.astype(float)).diff()
+
+
+class EndgameDriftShareLast60(BaseFeature):
+    name = "endgame_drift_share_last60"
+    description = "Sum of log returns in 15:00–15:59 divided by total O→C log return (RTH only)."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=list(self.required_full_columns))
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            gr = g.between_time("09:30", "15:59")["close"].dropna()
+            r = _logret(gr).dropna()
+            if r.empty:
+                out[sym] = float("nan")
+                continue
+            total = float(r.sum())
+            if np.abs(total) < 1e-12:
+                out[sym] = float("nan")
+                continue
+            win = g.between_time("15:00", "15:59").index
+            num = float(r.loc[r.index.intersection(win)].sum())
+            out[sym] = num / total
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = EndgameDriftShareLast60()

--- a/cube2mat/features/higuchi_fd_logret_kmax7.py
+++ b/cube2mat/features/higuchi_fd_logret_kmax7.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+import datetime as dt, numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+
+def _logret(s: pd.Series) -> pd.Series:
+    return np.log(s.astype(float)).diff()
+
+
+def _higuchi_fd(x: np.ndarray, kmax: int = 7) -> float:
+    N = x.size
+    if N < kmax + 2:
+        return float("nan")
+    Lk = []
+    K = []
+    for k in range(2, kmax + 1):
+        Lm = []
+        for m in range(k):
+            idx = np.arange(m, N, k)
+            if idx.size < 2:
+                continue
+            y = x[idx]
+            L = np.sum(np.abs(np.diff(y))) * (N - 1) / ((idx.size - 1) * k)
+            Lm.append(L)
+        if len(Lm) == 0:
+            continue
+        Lk.append(np.mean(Lm))
+        K.append(1.0 / k)
+    if len(Lk) < 2:
+        return float("nan")
+    X = np.log(K)
+    Y = np.log(Lk)
+    slope = np.polyfit(X, Y, 1)[0]
+    return float(slope)
+
+
+class HiguchiFDLogRetKmax7(BaseFeature):
+    name = "higuchi_fd_logret_kmax7"
+    description = "Higuchi fractal dimension estimate of log returns (k_max=7) within RTH."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=["symbol", "time", "close"])
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            r = _logret(_rth(g)["close"]).dropna().values
+            out[sym] = _higuchi_fd(r, kmax=7)
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = HiguchiFDLogRetKmax7()

--- a/cube2mat/features/lz_complexity_signret.py
+++ b/cube2mat/features/lz_complexity_signret.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+import datetime as dt, numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+
+def _logret(s: pd.Series) -> pd.Series:
+    return np.log(s.astype(float)).diff()
+
+
+def _lz_complexity_binary(seq: str) -> float:
+    n = len(seq)
+    if n == 0:
+        return float("nan")
+    i = 0
+    c = 0
+    while i < n:
+        l = 1
+        while i + l <= n and seq[i : i + l] in seq[:i]:
+            l += 1
+        c += 1
+        i += l
+    norm = (n / np.log2(n)) if n > 1 else 1.0
+    return float(c / norm)
+
+
+class LZComplexitySignRet(BaseFeature):
+    name = "lz_complexity_signret"
+    description = "Lempel–Ziv complexity of the sign of log returns (zeros dropped), normalized by n/log2(n)."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=["symbol", "time", "close"])
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            r = np.sign(_logret(_rth(g)["close"]).dropna().values)
+            r = r[r != 0]
+            s = "".join("1" if v > 0 else "0" for v in r)
+            out[sym] = _lz_complexity_binary(s)
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = LZComplexitySignRet()

--- a/cube2mat/features/midrange_cross_count.py
+++ b/cube2mat/features/midrange_cross_count.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+import datetime as dt, numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+
+class MidRangeCrossCount(BaseFeature):
+    name = "midrange_cross_count"
+    description = "Count of sign flips of (close − midrange) where midrange = (H+L)/2 using RTH session H/L; zeros ignored."
+    required_full_columns = ("symbol", "time", "high", "low", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=list(self.required_full_columns))
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            d = _rth(g)[["high", "low", "close"]].dropna()
+            if d.empty:
+                out[sym] = float("nan")
+                continue
+            H, L = float(d["high"].max()), float(d["low"].min())
+            mid = (H + L) / 2.0
+            x = d["close"].astype(float) - mid
+            s = np.sign(x.values)
+            s = s[s != 0]
+            out[sym] = float((s[1:] != s[:-1]).sum()) if s.size >= 2 else float("nan")
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = MidRangeCrossCount()

--- a/cube2mat/features/motif_ascending_share_m3_close.py
+++ b/cube2mat/features/motif_ascending_share_m3_close.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+import datetime as dt, numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+
+class MotifAscendingShareM3Close(BaseFeature):
+    name = "motif_ascending_share_m3_close"
+    description = "Share of 3-bar windows where close is strictly increasing (ordinal motif [0,1,2]) within RTH."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=["symbol", "time", "close"])
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            x = _rth(g)["close"].astype(float).dropna().values
+            n = x.size
+            if n < 3:
+                out[sym] = float("nan")
+                continue
+            cnt = 0
+            for i in range(n - 2):
+                if x[i] < x[i + 1] < x[i + 2]:
+                    cnt += 1
+            out[sym] = float(cnt / (n - 2))
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = MotifAscendingShareM3Close()

--- a/cube2mat/features/motif_zigzag_share_m3_close.py
+++ b/cube2mat/features/motif_zigzag_share_m3_close.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+import datetime as dt, numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+
+class MotifZigZagShareM3Close(BaseFeature):
+    name = "motif_zigzag_share_m3_close"
+    description = "Share of 3-bar windows where the middle close is a strict local extremum (peak or trough) within RTH."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=["symbol", "time", "close"])
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            x = _rth(g)["close"].astype(float).dropna().values
+            n = x.size
+            if n < 3:
+                out[sym] = float("nan")
+                continue
+            cnt = 0
+            for i in range(n - 2):
+                m1, m2, m3 = x[i], x[i + 1], x[i + 2]
+                if (m2 > m1 and m2 > m3) or (m2 < m1 and m2 < m3):
+                    cnt += 1
+            out[sym] = float(cnt / (n - 2))
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = MotifZigZagShareM3Close()

--- a/cube2mat/features/mutual_info_ret_volume_q8.py
+++ b/cube2mat/features/mutual_info_ret_volume_q8.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+import datetime as dt, numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+
+def _logret(s: pd.Series) -> pd.Series:
+    return np.log(s.astype(float)).diff()
+
+
+def _quantile_bins(x: np.ndarray, q: int):
+    if x.size == 0:
+        return None
+    qs = np.linspace(0, 1, q + 1)
+    edges = np.unique(np.quantile(x, qs))
+    if edges.size < 2:
+        return None
+    return edges
+
+
+def _mutual_info(x: np.ndarray, y: np.ndarray, qx: int = 8, qy: int = 8) -> float:
+    bx = _quantile_bins(x, qx)
+    by = _quantile_bins(y, qy)
+    if bx is None or by is None:
+        return float("nan")
+    ix = np.digitize(x, bx[1:-1], right=False)
+    iy = np.digitize(y, by[1:-1], right=False)
+    kx, ky = bx.size - 1, by.size - 1
+    joint = np.zeros((kx, ky), dtype=float)
+    for a, b in zip(ix, iy):
+        joint[a, b] += 1.0
+    joint_sum = joint.sum()
+    if joint_sum <= 0:
+        return float("nan")
+    px = joint.sum(axis=1) / joint_sum
+    py = joint.sum(axis=0) / joint_sum
+    pxy = joint / joint_sum
+    nz = pxy > 0
+    mi = np.sum(pxy[nz] * np.log2(pxy[nz] / (px[:, None] * py[None, :])[nz]))
+    return float(mi)
+
+
+class MutualInfoRetVolumeQ8(BaseFeature):
+    name = "mutual_info_ret_volume_q8"
+    description = "Mutual information I(R;V) in bits between log returns and volume using quantile bins (8×8) within RTH."
+    required_full_columns = ("symbol", "time", "close", "volume")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=["symbol", "time", "close", "volume"])
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            gg = _rth(g)[["close", "volume"]].dropna()
+            r = _logret(gg["close"]).dropna()
+            if r.empty:
+                out[sym] = float("nan")
+                continue
+            v = gg["volume"].astype(float).reindex(r.index).values
+            out[sym] = _mutual_info(r.values, v, 8, 8)
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = MutualInfoRetVolumeQ8()

--- a/cube2mat/features/next3_absret_highvol_minus_lowvol.py
+++ b/cube2mat/features/next3_absret_highvol_minus_lowvol.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+import datetime as dt, numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+
+def _logret(s: pd.Series) -> pd.Series:
+    return np.log(s.astype(float)).diff()
+
+
+class Next3AbsRetHighVolMinusLowVol(BaseFeature):
+    name = "next3_absret_highvol_minus_lowvol"
+    description = "E[Σ_{i=1..3}|r_{t+i}| | vol_t≥Q90] − E[Σ_{i=1..3}|r_{t+i}| | vol_t≤Q10], within RTH."
+    required_full_columns = ("symbol", "time", "close", "volume")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=["symbol", "time", "close", "volume"])
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            gg = _rth(g)[["close", "volume"]].dropna()
+            r = _logret(gg["close"]).dropna()
+            if r.size < 4:
+                out[sym] = float("nan")
+                continue
+            vol = gg["volume"].astype(float).reindex(r.index)
+            v90 = float(np.nanquantile(vol.values, 0.90))
+            v10 = float(np.nanquantile(vol.values, 0.10))
+            hv = np.where(vol.values >= v90)[0]
+            lv = np.where(vol.values <= v10)[0]
+            def _next3_abs(i: int) -> float:
+                j = min(i + 3, r.size - 1)
+                return float(np.abs(r.values[i + 1 : j + 1]).sum()) if i + 1 < r.size else np.nan
+            hv_vals = [_next3_abs(i) for i in hv if i + 1 < r.size]
+            lv_vals = [_next3_abs(i) for i in lv if i + 1 < r.size]
+            hvm = np.nanmean(hv_vals) if len(hv_vals) > 0 else np.nan
+            lvm = np.nanmean(lv_vals) if len(lv_vals) > 0 else np.nan
+            out[sym] = float(hvm - lvm) if np.isfinite(hvm) and np.isfinite(lvm) else float("nan")
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = Next3AbsRetHighVolMinusLowVol()

--- a/cube2mat/features/opening_impulse_share_30m.py
+++ b/cube2mat/features/opening_impulse_share_30m.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+import datetime as dt, numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _logret(s: pd.Series) -> pd.Series:
+    return np.log(s.astype(float)).diff()
+
+
+class OpeningImpulseShare30m(BaseFeature):
+    name = "opening_impulse_share_30m"
+    description = "Sum of log returns in 09:30–09:59 divided by total O→C log return (RTH only)."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=list(self.required_full_columns))
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            gr = g.between_time("09:30", "15:59")["close"].dropna()
+            r = _logret(gr).dropna()
+            if r.empty:
+                out[sym] = float("nan")
+                continue
+            total = float(r.sum())
+            if np.abs(total) < 1e-12:
+                out[sym] = float("nan")
+                continue
+            win = g.between_time("09:30", "09:59").index
+            num = float(r.loc[r.index.intersection(win)].sum())
+            out[sym] = num / total
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = OpeningImpulseShare30m()

--- a/cube2mat/features/permutation_entropy_logret_m3.py
+++ b/cube2mat/features/permutation_entropy_logret_m3.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+import datetime as dt, numpy as np, pandas as pd, math
+from feature_base import BaseFeature, FeatureContext
+
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+
+def _logret(s: pd.Series) -> pd.Series:
+    return np.log(s.astype(float)).diff()
+
+
+def _perm_entropy(x: np.ndarray, m: int = 3) -> float:
+    n = x.size
+    if n < m:
+        return float("nan")
+    counts: dict[tuple[int, ...], int] = {}
+    for i in range(n - m + 1):
+        w = x[i : i + m]
+        order = tuple(np.argsort(np.argsort(w, kind="mergesort"), kind="mergesort"))
+        counts[order] = counts.get(order, 0) + 1
+    p = np.array(list(counts.values()), dtype=float)
+    p = p / p.sum()
+    H = -np.sum(p * np.log2(p))
+    return float(H / np.log2(math.factorial(m)))
+
+
+class PermutationEntropyLogRetM3(BaseFeature):
+    name = "permutation_entropy_logret_m3"
+    description = "Permutation entropy (m=3) of RTH log returns, normalized to [0,1] (ordinal patterns)."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=["symbol", "time", "close"])
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            r = _logret(_rth(g)["close"]).dropna().values
+            out[sym] = _perm_entropy(r, m=3)
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = PermutationEntropyLogRetM3()

--- a/cube2mat/features/price_above_median_share.py
+++ b/cube2mat/features/price_above_median_share.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+import datetime as dt, numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+
+class PriceAboveMedianShare(BaseFeature):
+    name = "price_above_median_share"
+    description = "Share of RTH bars with close strictly above the RTH median close."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=list(self.required_full_columns))
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            s = _rth(g)["close"].astype(float).dropna()
+            if s.empty:
+                out[sym] = float("nan")
+                continue
+            med = float(np.median(s.values))
+            out[sym] = float((s.values > med).mean())
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = PriceAboveMedianShare()

--- a/cube2mat/features/quietest_stretch_maxlen_q25_absret_frac.py
+++ b/cube2mat/features/quietest_stretch_maxlen_q25_absret_frac.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+import datetime as dt, numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+
+def _logret(s: pd.Series) -> pd.Series:
+    return np.log(s.astype(float)).diff()
+
+
+def _longest_true_run(mask: np.ndarray) -> int:
+    if mask.size == 0:
+        return 0
+    best = cnt = 0
+    for v in mask:
+        if v:
+            cnt += 1
+        else:
+            best = max(best, cnt)
+            cnt = 0
+    return max(best, cnt)
+
+
+class QuietestStretchMaxLenQ25AbsRetFrac(BaseFeature):
+    name = "quietest_stretch_maxlen_q25_absret_frac"
+    description = (
+        "Longest run length (as a fraction of return count) where |r| ≤ Q25(|r|) within RTH (log-returns)."
+    )
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=list(self.required_full_columns))
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            r = _logret(_rth(g)["close"]).dropna().values
+            n = r.size
+            if n == 0:
+                out[sym] = float("nan")
+                continue
+            thr = float(np.nanquantile(np.abs(r), 0.25))
+            mask = np.abs(r) <= thr
+            L = _longest_true_run(mask)
+            out[sym] = float(L / n)
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = QuietestStretchMaxLenQ25AbsRetFrac()

--- a/cube2mat/features/run_length_entropy_signret.py
+++ b/cube2mat/features/run_length_entropy_signret.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+import datetime as dt, numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+
+def _logret(s: pd.Series) -> pd.Series:
+    return np.log(s.astype(float)).diff()
+
+
+def _run_lengths(s: np.ndarray) -> list[int]:
+    s = s[s != 0]
+    if s.size == 0:
+        return []
+    lens: list[int] = []
+    curr = s[0]
+    L = 1
+    for v in s[1:]:
+        if v == curr:
+            L += 1
+        else:
+            lens.append(L)
+            curr = v
+            L = 1
+    lens.append(L)
+    return lens
+
+
+class RunLengthEntropySignRet(BaseFeature):
+    name = "run_length_entropy_signret"
+    description = "Shannon entropy of sign-run length distribution for log returns in RTH, normalized by log2(#unique lengths)."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=["symbol", "time", "close"])
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            s = np.sign(_logret(_rth(g)["close"]).dropna().values)
+            lens = _run_lengths(s)
+            if len(lens) == 0:
+                out[sym] = float("nan")
+                continue
+            vals, cnts = np.unique(lens, return_counts=True)
+            p = cnts.astype(float) / cnts.sum()
+            H = -np.sum(p * np.log2(p))
+            out[sym] = float(H / np.log2(len(vals))) if len(vals) > 1 else 0.0
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = RunLengthEntropySignRet()

--- a/cube2mat/features/rv_per_trade.py
+++ b/cube2mat/features/rv_per_trade.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+import datetime as dt, numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+
+def _logret(s: pd.Series) -> pd.Series:
+    return np.log(s.astype(float)).diff()
+
+
+class RVPerTrade(BaseFeature):
+    name = "rv_per_trade"
+    description = "Realized variance Σ r^2 divided by total trade count Σ n over RTH."
+    required_full_columns = ("symbol", "time", "close", "n")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=["symbol", "time", "close", "n"])
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            gg = _rth(g)[["close", "n"]].dropna()
+            r = _logret(gg["close"]).dropna().values
+            totn = float(gg["n"].sum())
+            out[sym] = float(np.sum(r ** 2) / totn) if r.size > 0 and totn > 0 and np.isfinite(totn) else float("nan")
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = RVPerTrade()

--- a/cube2mat/features/sample_entropy_absret_m2_r02.py
+++ b/cube2mat/features/sample_entropy_absret_m2_r02.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+import datetime as dt, numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+
+def _logret(s: pd.Series) -> pd.Series:
+    return np.log(s.astype(float)).diff()
+
+
+def _sampen(x: np.ndarray, m: int = 2, r: float | None = None) -> float:
+    x = np.asarray(x, dtype=float)
+    n = x.size
+    if n <= m + 1:
+        return float("nan")
+    if r is None:
+        r = 0.2 * np.nanstd(x)
+        if not np.isfinite(r) or r <= 0:
+            return float("nan")
+    def _count(mm: int) -> int:
+        cnt = 0
+        for i in range(n - mm):
+            xi = x[i : i + mm]
+            for j in range(i + 1, n - mm + 1):
+                xj = x[j : j + mm]
+                if np.max(np.abs(xi - xj)) <= r:
+                    cnt += 1
+        return cnt
+    A = _count(m + 1)
+    B = _count(m)
+    return float(-np.log(A / B)) if A > 0 and B > 0 else float("nan")
+
+
+class SampleEntropyAbsRetM2R02(BaseFeature):
+    name = "sample_entropy_absret_m2_r02"
+    description = "Sample Entropy of |log returns| with m=2, r=0.2·std(|r|) within RTH."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=["symbol", "time", "close"])
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            r = np.abs(_logret(_rth(g)["close"]).dropna().values)
+            out[sym] = _sampen(r, m=2, r=0.2 * np.nanstd(r)) if r.size > 5 else float("nan")
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = SampleEntropyAbsRetM2R02()

--- a/cube2mat/features/spearman_absret_volume.py
+++ b/cube2mat/features/spearman_absret_volume.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+import datetime as dt, numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+
+def _logret(s: pd.Series) -> pd.Series:
+    return np.log(s.astype(float)).diff()
+
+
+def _spearman(a: np.ndarray, b: np.ndarray) -> float:
+    a = pd.Series(a).rank(method="average").values
+    b = pd.Series(b).rank(method="average").values
+    if a.size < 2:
+        return float("nan")
+    return float(np.corrcoef(a, b)[0, 1])
+
+
+class SpearmanAbsRetVolume(BaseFeature):
+    name = "spearman_absret_volume"
+    description = "Spearman rank correlation between |log returns| and volume in RTH."
+    required_full_columns = ("symbol", "time", "close", "volume")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=["symbol", "time", "close", "volume"])
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            gg = _rth(g)[["close", "volume"]].dropna()
+            r = _logret(gg["close"]).dropna()
+            if r.empty:
+                out[sym] = float("nan")
+                continue
+            v = gg["volume"].astype(float).reindex(r.index).values
+            out[sym] = _spearman(np.abs(r.values), v)
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = SpearmanAbsRetVolume()

--- a/cube2mat/features/time_to_half_openclose_ret_frac.py
+++ b/cube2mat/features/time_to_half_openclose_ret_frac.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+import datetime as dt, numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+
+def _logret(s: pd.Series) -> pd.Series:
+    return np.log(s.astype(float)).diff()
+
+
+class TimeToHalfOpenCloseRetFrac(BaseFeature):
+    name = "time_to_half_openclose_ret_frac"
+    description = (
+        "Fraction of RTH return observations elapsed when cumulative log return "
+        "first reaches 50% of |total O→C log return| (direction-aware)."
+    )
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=list(self.required_full_columns))
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            r = _logret(_rth(g)["close"]).dropna().values
+            n = r.size
+            if n == 0:
+                out[sym] = float("nan")
+                continue
+            total = float(np.sum(r))
+            if not np.isfinite(total) or np.abs(total) < 1e-12:
+                out[sym] = float("nan")
+                continue
+            target = 0.5 * np.abs(total)
+            sgn = np.sign(total)
+            cr = np.cumsum(r * sgn)
+            idx = np.where(cr >= target)[0]
+            out[sym] = float((idx[0] + 1) / n) if idx.size > 0 else float("nan")
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = TimeToHalfOpenCloseRetFrac()

--- a/cube2mat/features/transition_entropy_signret.py
+++ b/cube2mat/features/transition_entropy_signret.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+import datetime as dt, numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+
+def _logret(s: pd.Series) -> pd.Series:
+    return np.log(s.astype(float)).diff()
+
+
+class TransitionEntropySignRet(BaseFeature):
+    name = "transition_entropy_signret"
+    description = "Conditional entropy H(S_t | S_{t-1}) of sign(log returns) over RTH, normalized by log2(2)=1."
+    required_full_columns = ("symbol", "time", "close")
+    required_pv_columns = ("symbol",)
+
+    @staticmethod
+    def _cond_entropy(s: np.ndarray) -> float:
+        s = s[s != 0]
+        if s.size < 2:
+            return float("nan")
+        tr = np.zeros((2, 2), dtype=float)
+        prev = (s[:-1] > 0).astype(int)
+        nxt = (s[1:] > 0).astype(int)
+        for a, b in zip(prev, nxt):
+            tr[a, b] += 1.0
+        rowsum = tr.sum(axis=1)
+        if rowsum.sum() == 0:
+            return float("nan")
+        H = 0.0
+        for i in range(2):
+            if rowsum[i] == 0:
+                continue
+            p_row = tr[i] / rowsum[i]
+            p_row = p_row[p_row > 0]
+            H += (rowsum[i] / rowsum.sum()) * (-np.sum(p_row * np.log2(p_row)))
+        return float(H)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=["symbol", "time", "close"])
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            s = np.sign(_logret(_rth(g)["close"]).dropna().values)
+            out[sym] = self._cond_entropy(s)
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = TransitionEntropySignRet()

--- a/cube2mat/features/up_prob_highvol_minus_lowvol.py
+++ b/cube2mat/features/up_prob_highvol_minus_lowvol.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+import datetime as dt, numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+
+def _logret(s: pd.Series) -> pd.Series:
+    return np.log(s.astype(float)).diff()
+
+
+class UpProbHighVolMinusLowVol(BaseFeature):
+    name = "up_prob_highvol_minus_lowvol"
+    description = "ΔP(up): P(r>0 | volume≥Q90) − P(r>0 | volume≤Q10) using RTH log returns aligned to volume at time t."
+    required_full_columns = ("symbol", "time", "close", "volume")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=["symbol", "time", "close", "volume"])
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            gg = _rth(g)[["close", "volume"]].dropna()
+            r = _logret(gg["close"]).dropna()
+            if r.empty:
+                out[sym] = float("nan")
+                continue
+            vol = gg["volume"].astype(float).reindex(r.index)
+            v90 = float(np.nanquantile(vol.values, 0.90))
+            v10 = float(np.nanquantile(vol.values, 0.10))
+            hv = vol.values >= v90
+            lv = vol.values <= v10
+            ph = (r.values[hv] > 0).mean() if hv.sum() > 0 else np.nan
+            pl = (r.values[lv] > 0).mean() if lv.sum() > 0 else np.nan
+            out[sym] = float(ph - pl) if np.isfinite(ph) and np.isfinite(pl) else float("nan")
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = UpProbHighVolMinusLowVol()

--- a/cube2mat/features/volume_return_cokurtosis22.py
+++ b/cube2mat/features/volume_return_cokurtosis22.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+import datetime as dt, numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+
+def _logret(s: pd.Series) -> pd.Series:
+    return np.log(s.astype(float)).diff()
+
+
+class VolumeReturnCoKurtosis22(BaseFeature):
+    name = "volume_return_cokurtosis22"
+    description = "Co-kurtosis(2,2): E[(V-μV)^2 (R-μR)^2] / (σV^2 σR^2) for volume and log returns in RTH."
+    required_full_columns = ("symbol", "time", "close", "volume")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=["symbol", "time", "close", "volume"])
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            gg = _rth(g)[["close", "volume"]].dropna()
+            r = _logret(gg["close"]).dropna()
+            if r.empty:
+                out[sym] = float("nan")
+                continue
+            v = gg["volume"].astype(float).reindex(r.index).values
+            rv = r.values
+            vmu, rmu = np.mean(v), np.mean(rv)
+            sv, sr = np.std(v, ddof=1), np.std(rv, ddof=1)
+            if sv <= 0 or sr <= 0 or not np.isfinite(sv) or not np.isfinite(sr):
+                out[sym] = float("nan")
+                continue
+            num = np.mean(((v - vmu) ** 2) * ((rv - rmu) ** 2))
+            out[sym] = float(num / (sv ** 2 * sr ** 2))
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = VolumeReturnCoKurtosis22()

--- a/cube2mat/features/volume_return_coskewness.py
+++ b/cube2mat/features/volume_return_coskewness.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+import datetime as dt, numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+
+def _logret(s: pd.Series) -> pd.Series:
+    return np.log(s.astype(float)).diff()
+
+
+def _safe_std(x: np.ndarray) -> float:
+    x = np.asarray(x, float)
+    return float(np.std(x, ddof=1)) if x.size >= 2 else np.nan
+
+
+class VolumeReturnCoSkewness(BaseFeature):
+    name = "volume_return_coskewness"
+    description = "Co-skewness E[(V-μV)^2 (R-μR)] / (σV^2 σR) between volume and log returns in RTH."
+    required_full_columns = ("symbol", "time", "close", "volume")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=["symbol", "time", "close", "volume"])
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            gg = _rth(g)[["close", "volume"]].dropna()
+            r = _logret(gg["close"]).dropna()
+            if r.empty:
+                out[sym] = float("nan")
+                continue
+            v = gg["volume"].astype(float).reindex(r.index).values
+            rv = r.values
+            vmu, rmu = float(np.mean(v)), float(np.mean(rv))
+            sv, sr = _safe_std(v), _safe_std(rv)
+            if not (np.isfinite(sv) and sv > 0 and np.isfinite(sr) and sr > 0):
+                out[sym] = float("nan")
+                continue
+            num = np.mean(((v - vmu) ** 2) * (rv - rmu))
+            out[sym] = float(num / (sv ** 2 * sr))
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = VolumeReturnCoSkewness()

--- a/cube2mat/features/volume_weighted_simple_return.py
+++ b/cube2mat/features/volume_weighted_simple_return.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+import datetime as dt, numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+
+class VolumeWeightedSimpleReturn(BaseFeature):
+    name = "volume_weighted_simple_return"
+    description = "Volume-weighted mean of simple returns within RTH: Σ(v_t * (close_t/close_{t-1} - 1))/Σ v_t."
+    required_full_columns = ("symbol", "time", "close", "volume")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=list(self.required_full_columns))
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            z = _rth(g)[["close", "volume"]].dropna()
+            if z.empty or z.shape[0] < 2:
+                out[sym] = float("nan")
+                continue
+            ret = z["close"].astype(float).pct_change().dropna()
+            vol = z["volume"].astype(float).reindex(ret.index)
+            denom = float(vol.sum())
+            num = float((vol * ret).sum())
+            out[sym] = num / denom if denom > 0 and np.isfinite(denom) else float("nan")
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = VolumeWeightedSimpleReturn()

--- a/cube2mat/features/vwap_position_in_range.py
+++ b/cube2mat/features/vwap_position_in_range.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+import datetime as dt, numpy as np, pandas as pd
+from feature_base import BaseFeature, FeatureContext
+
+
+def _rth(df: pd.DataFrame) -> pd.DataFrame:
+    return df.between_time("09:30", "15:59")
+
+
+class VWAPPositionInRange(BaseFeature):
+    name = "vwap_position_in_range"
+    description = "Position of session VWAP in the day's H-L range: (VWAP - L)/(H - L)."
+    required_full_columns = ("symbol", "time", "high", "low", "vwap", "volume")
+    required_pv_columns = ("symbol",)
+
+    def process_date(self, ctx: FeatureContext, date: dt.date):
+        df = self.load_full(ctx, date, columns=list(self.required_full_columns))
+        pv = self.load_pv(ctx, date, columns=["symbol"])
+        if df is None or pv is None:
+            return None
+        df = self.ensure_et_index(df, "time", ctx.tz)
+        out: dict[str, float] = {}
+        for sym, g in df.groupby("symbol", observed=True):
+            d = _rth(g)[["high", "low", "vwap", "volume"]].dropna()
+            if d.empty:
+                out[sym] = float("nan")
+                continue
+            H, L = float(d["high"].max()), float(d["low"].min())
+            rng = H - L
+            if not (np.isfinite(rng) and rng > 0):
+                out[sym] = float("nan")
+                continue
+            totv = float(d["volume"].sum())
+            if not (np.isfinite(totv) and totv > 0):
+                out[sym] = float("nan")
+                continue
+            vwap_sess = float((d["vwap"] * d["volume"]).sum() / totv)
+            out[sym] = float((vwap_sess - L) / rng)
+        res = pv[["symbol"]].copy()
+        res["value"] = res["symbol"].map(out)
+        return res
+
+
+feature = VWAPPositionInRange()


### PR DESCRIPTION
## Summary
- add end-of-day position and range-based shape metrics
- introduce complexity metrics like permutation entropy and Higuchi fractal dimension
- add volume/return coupling measures including co-skewness and Spearman correlation

## Testing
- `python -m py_compile cube2mat/features/absret_per_volume.py cube2mat/features/approx_entropy_absret_m2_r02.py cube2mat/features/close_to_edge_distance_frac.py cube2mat/features/end_position_in_range.py cube2mat/features/endgame_drift_share_last60.py cube2mat/features/higuchi_fd_logret_kmax7.py cube2mat/features/lz_complexity_signret.py cube2mat/features/midrange_cross_count.py cube2mat/features/motif_ascending_share_m3_close.py cube2mat/features/motif_zigzag_share_m3_close.py cube2mat/features/mutual_info_ret_volume_q8.py cube2mat/features/next3_absret_highvol_minus_lowvol.py cube2mat/features/opening_impulse_share_30m.py cube2mat/features/permutation_entropy_logret_m3.py cube2mat/features/price_above_median_share.py cube2mat/features/quietest_stretch_maxlen_q25_absret_frac.py cube2mat/features/run_length_entropy_signret.py cube2mat/features/rv_per_trade.py cube2mat/features/sample_entropy_absret_m2_r02.py cube2mat/features/spearman_absret_volume.py cube2mat/features/time_to_half_openclose_ret_frac.py cube2mat/features/transition_entropy_signret.py cube2mat/features/up_prob_highvol_minus_lowvol.py cube2mat/features/volume_return_cokurtosis22.py cube2mat/features/volume_return_coskewness.py cube2mat/features/volume_weighted_simple_return.py cube2mat/features/vwap_position_in_range.py`
- ⚠️ `python cube2mat/runner_smoke_test.py` (missing pandas)
- ⚠️ `pip install pandas numpy` (proxy error)

------
https://chatgpt.com/codex/tasks/task_e_68a34bbe0410832abf7ab0ccc8198303